### PR TITLE
Chore: Allow SDC search by empty name and prevent by empty id

### DIFF
--- a/powerflex/sdc_datasource.go
+++ b/powerflex/sdc_datasource.go
@@ -66,10 +66,10 @@ func (d *sdcDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 	// Set state
 	searchFilter := sdcFilterType.All
-	if state.Name.ValueString() != "" {
+	if !state.Name.IsNull() {
 		searchFilter = sdcFilterType.ByName
 	}
-	if state.ID.ValueString() != "" {
+	if !state.ID.IsNull() {
 		searchFilter = sdcFilterType.ByID
 	}
 

--- a/powerflex/sdc_datasource_schema.go
+++ b/powerflex/sdc_datasource_schema.go
@@ -63,6 +63,7 @@ var SDCDataSourceScheme schema.Schema = schema.Schema{
 			Computed:    true,
 			Validators: []validator.String{
 				stringvalidator.ConflictsWith(path.MatchRoot("name")),
+				stringvalidator.LengthAtLeast(1),
 			},
 		},
 		"name": schema.StringAttribute{

--- a/powerflex/sdc_datasource_test.go
+++ b/powerflex/sdc_datasource_test.go
@@ -2,6 +2,7 @@ package powerflex
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -21,9 +22,9 @@ var sdcTestData sdcDataPoints
 func init() {
 	sdcTestData.noOfSdc = "1"
 	sdcTestData.noOflinks = "4"
-	sdcTestData.name = "powerflex_sdc26"
+	sdcTestData.name = ""
 	sdcTestData.sdcguid = "0877AE5E-BDBF-4E87-A002-218D9F883896"
-	sdcTestData.sdcip = ""
+	sdcTestData.sdcip = "10.247.96.90"
 	sdcTestData.systemid = "0e7a082862fedf0f"
 }
 
@@ -35,23 +36,40 @@ func TestSdcDataSource(t *testing.T) {
 			// Read testing
 			// Error here = https://github.com/hashicorp/terraform-plugin-sdk/pull/1077
 			{
-				Config: ProviderConfigForTesting + TestSdcDataSourceBlock,
+				Config: ProviderConfigForTesting + TestSdcDataSourceBlockOnlyID,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify number of sdc returned
 					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.#", sdcTestData.noOfSdc),
 					// Verify the first sdc to ensure all attributes are set
 					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.system_id", sdcTestData.systemid),
 					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.sdc_guid", sdcTestData.sdcguid),
-					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.name", sdcTestData.name),
-					// resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.sdc_ip", sdcTestData.sdcip),
+					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.name", ""),
+					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.sdc_ip", sdcTestData.sdcip),
 					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.0.links.#", sdcTestData.noOflinks),
 				),
 			},
 			{
-				Config: ProviderConfigForTesting + TestSdcDataSourceBlockOnlyID,
+				Config: ProviderConfigForTesting + TestSdcDataSourceByEmptyBlock,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify number of sdc returned
-					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.#", "133"),
+					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.#", "151"),
+					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "id", ""),
+					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "name", ""),
+				),
+			},
+			{
+				Config:      ProviderConfigForTesting + TestSdcDataSourceByEmptyIDNeg,
+				ExpectError: regexp.MustCompile(".*id.*"),
+			},
+			{
+				Config:      ProviderConfigForTesting + TestSdcDataSourceBlockBothNeg,
+				ExpectError: regexp.MustCompile(".*Invalid Attribute Combination.*"),
+			},
+			{
+				Config: ProviderConfigForTesting + TestSdcDataSourceByEmptyNameBlock,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify number of sdc returned
+					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "sdcs.#", "147"),
 					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "id", ""),
 					resource.TestCheckResourceAttr("data.powerflex_sdc.selected", "name", ""),
 				),
@@ -80,13 +98,22 @@ func TestSdcDataSourceByName(t *testing.T) {
 }
 
 var (
-	TestSdcDataSourceBlock = `data "powerflex_sdc" "selected" {
+	TestSdcDataSourceBlockOnlyID = `data "powerflex_sdc" "selected" {
 		id = "c423b09800000003"
 	}`
-	TestSdcDataSourceBlockOnlyID = `data "powerflex_sdc" "selected" {
+	TestSdcDataSourceByEmptyIDNeg = `data "powerflex_sdc" "selected" {
 		id = ""
+	}`
+	TestSdcDataSourceBlockBothNeg = `data "powerflex_sdc" "selected" {
+		id = ""
+		name = ""
 	}`
 	TestSdcDataSourceByNameBlock = `data "powerflex_sdc" "selected" {
 		name = "LGLW6092"
+	}`
+	TestSdcDataSourceByEmptyNameBlock = `data "powerflex_sdc" "selected" {
+		name = ""
+	}`
+	TestSdcDataSourceByEmptyBlock = `data "powerflex_sdc" "selected" {
 	}`
 )


### PR DESCRIPTION
We are allowing name to be empty because the API allows empty name for SDCs and someone may genuinely want to fetch all SDCs that have empty string as name.
Only an empty data block should fetch all SDCs in system.