### PR TITLE
Set default value of rf_cache_enabled for protection domain to true

### DIFF
--- a/docs/resources/protection_domain.md
+++ b/docs/resources/protection_domain.md
@@ -76,7 +76,7 @@ resource "powerflex_protection_domain" "pd" {
 - `protected_maintenance_mode_network_throttling_in_kbps` (Number) Maximum allowed IO for protected maintenance mode in KBps. The value `0` represents unlimited bandwidth. The default value is `0`.
 - `rebalance_network_throttling_in_kbps` (Number) Maximum allowed IO for rebalancing in KBps. The value `0` represents unlimited bandwidth. The default value is `0`.
 - `rebuild_network_throttling_in_kbps` (Number) Maximum allowed IO for rebuilding in KBps. The value `0` represents unlimited bandwidth. The default value is `0`.
-- `rf_cache_enabled` (Boolean) Whether SDS Rf Cache is enabled or not.
+- `rf_cache_enabled` (Boolean) Whether SDS Rf Cache is enabled or not. Default value is `true`.
 - `rf_cache_max_io_size_kb` (Number) Maximum IO of the SDS RF Cache in KB. Can be set only when `rf_cache_enabled` is set to `true`.
 - `rf_cache_operational_mode` (String) Operational Mode of the SDS RF Cache. Accepted values are `Read`, `Write`, `ReadAndWrite` and `WriteMiss`. Can be set only when `rf_cache_enabled` is set to `true`.
 - `rf_cache_page_size_kb` (Number) Page size of the SDS RF Cache in KB. Can be set only when `rf_cache_enabled` is set to `true`.

--- a/powerflex/protection_domain_resource_schema.go
+++ b/powerflex/protection_domain_resource_schema.go
@@ -50,11 +50,12 @@ var ProtectionDomainResourceSchema schema.Schema = schema.Schema{
 			Computed:            true,
 		},
 		"rf_cache_enabled": schema.BoolAttribute{
-			Description:         "Whether SDS Rf Cache is enabled or not.",
-			MarkdownDescription: "Whether SDS Rf Cache is enabled or not.",
+			Description:         "Whether SDS Rf Cache is enabled or not. Default value is 'true'.",
+			MarkdownDescription: "Whether SDS Rf Cache is enabled or not. Default value is `true`.",
 			Computed:            true,
 			Optional:            true,
 			PlanModifiers: []planmodifier.Bool{
+				boolDefault(true),
 				boolplanmodifier.UseStateForUnknown(),
 			},
 		},

--- a/powerflex/protection_domain_resource_test.go
+++ b/powerflex/protection_domain_resource_test.go
@@ -164,6 +164,8 @@ func TestAccPDResource(t *testing.T) {
 				Config: ProviderConfigForTesting + createPDTest,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "test_acc_pd_1"),
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "rf_cache_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rebuild_network_throttling_in_kbps", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rebalance_network_throttling_in_kbps", "0"),
 					resource.TestCheckResourceAttr(resourceName, "vtree_migration_network_throttling_in_kbps", "0"),


### PR DESCRIPTION
```
Running tool: /usr/local/go/bin/go test -timeout 5h -run ^(TestAccPDResource|TestAccPDResource2|TestApiLinks)$ terraform-provider-powerflex/powerflex -v

=== RUN   TestAccPDResource
--- PASS: TestAccPDResource (31.02s)
=== RUN   TestAccPDResource2
--- PASS: TestAccPDResource2 (7.97s)
=== RUN   TestApiLinks
--- PASS: TestApiLinks (0.00s)
PASS
ok      terraform-provider-powerflex/powerflex  39.058s


> Test run finished at 5/2/2023, 3:19:34 PM <
```