### PR TITLE
volume and snapshot sdc_list idempotency fix

### DIFF
--- a/powerflex/snapshot_resource_test.go
+++ b/powerflex/snapshot_resource_test.go
@@ -372,6 +372,15 @@ func TestAccSnapshotResourceDuplicateSdc(t *testing.T) {
 	}
 	`
 
+	createSsUnspecifiedSdc := createVolForSs + `
+	resource "powerflex_snapshot" "snapshots-create-access-mode-sdc-map" {
+		name = "snapshots-create-epsilon"
+		volume_id = resource.powerflex_volume.ref-vol.id
+		access_mode = "ReadWrite"
+		size = 16
+	}
+	`
+
 	createSsNoSdc := createVolForSs + `
 	resource "powerflex_snapshot" "snapshots-create-access-mode-sdc-map" {
 		name = "snapshots-create-epsilon"
@@ -392,6 +401,12 @@ func TestAccSnapshotResourceDuplicateSdc(t *testing.T) {
 			},
 			{
 				Config: ProviderConfigForTesting + createSsDuplicateSdcPos,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerflex_snapshot.snapshots-create-access-mode-sdc-map", "sdc_list.#", "1"),
+				),
+			},
+			{
+				Config: ProviderConfigForTesting + createSsUnspecifiedSdc,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("powerflex_snapshot.snapshots-create-access-mode-sdc-map", "sdc_list.#", "1"),
 				),

--- a/powerflex/volume_resource.go
+++ b/powerflex/volume_resource.go
@@ -73,6 +73,10 @@ func (r *volumeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		resp.Diagnostics.Append(diags...)
 	}
 
+	if plan.SdcList.IsUnknown() {
+		return
+	}
+
 	sr, err := getFirstSystem(r.client)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -311,6 +315,12 @@ func (r *volumeResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// in case of update, if sdc_list plan is unknown, we go for idempotency, ie. we shall make no changes
+	if plan.SdcList.IsUnknown() {
+		plan.SdcList = state.SdcList
+	}
+
 	volsplan, err2 := r.client.GetVolume("", state.ID.ValueString(), "", "", false)
 	if err2 != nil {
 		resp.Diagnostics.AddError(

--- a/powerflex/volume_resource_test.go
+++ b/powerflex/volume_resource_test.go
@@ -578,6 +578,16 @@ func TestAccVolumeResourceUnMapAll(t *testing.T) {
 	  }
 	`
 
+	updateIdemp := `
+	resource "powerflex_volume" "avengers-volume-create"{
+		name = "avengers-volume-create"
+		protection_domain_name = "domain1"
+		storage_pool_name = "pool1"
+		size = 8
+		access_mode = "ReadWrite"
+	  }
+	`
+
 	update := `
 	resource "powerflex_volume" "avengers-volume-create"{
 		name = "avengers-volume-create"
@@ -600,6 +610,12 @@ func TestAccVolumeResourceUnMapAll(t *testing.T) {
 				),
 				// TODO
 				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: ProviderConfigForTesting + updateIdemp,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerflex_volume.avengers-volume-create", "sdc_list.#", "1"),
+				),
 			},
 			{
 				Config: ProviderConfigForTesting + update,


### PR DESCRIPTION


Volume and Sanpshot sdc_list has an idempotency issue when used in conjunction with the new sdc_list resource. This PR fixes it.

![image](https://user-images.githubusercontent.com/120458947/236801156-133f98af-b857-4912-8003-2be80c43f959.png)

Earlier =========

```

# Createing all volumes and mappings ---------------------------------
root@lglap049:~/test-tf# terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # powerflex_sdc_volumes_mapping.mapping-test will be created
  + resource "powerflex_sdc_volumes_mapping" "mapping-test" {
      + id          = "e3ce46c500000002"
      + name        = "Terraform_sdc2"
      + volume_list = [
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 19
              + limit_iops       = 140
              + volume_id        = (known after apply)
              + volume_name      = (known after apply)
            },
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 20
              + limit_iops       = 141
              + volume_id        = (known after apply)
              + volume_name      = (known after apply)
            },
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 20
              + limit_iops       = 141
              + volume_id        = (known after apply)
              + volume_name      = (known after apply)
            },
        ]
    }

  # powerflex_snapshot.ss will be created
  + resource "powerflex_snapshot" "ss" {
      + access_mode        = "ReadOnly"
      + capacity_unit      = "GB"
      + id                 = (known after apply)
      + lock_auto_snapshot = (known after apply)
      + name               = "sdc_map_test_ss_rounak_12"
      + remove_mode        = "ONLY_ME"
      + retention_unit     = "hours"
      + sdc_list           = [
        ]
      + size               = (known after apply)
      + size_in_kb         = (known after apply)
      + volume_id          = (known after apply)
      + volume_name        = (known after apply)
    }

  # powerflex_volume.vol1 will be created
  + resource "powerflex_volume" "vol1" {
      + access_mode            = "ReadOnly"
      + capacity_unit          = "GB"
      + compression_method     = (known after apply)
      + id                     = (known after apply)
      + name                   = "sdc_map_test_rounak_1"
      + protection_domain_id   = (known after apply)
      + protection_domain_name = "domain1"
      + remove_mode            = "ONLY_ME"
      + sdc_list               = [
        ]
      + size                   = 8
      + size_in_kb             = 8388608
      + storage_pool_id        = (known after apply)
      + storage_pool_name      = "pool1"
      + use_rm_cache           = (known after apply)
      + volume_type            = "ThinProvisioned"
    }

  # powerflex_volume.vol2 will be created
  + resource "powerflex_volume" "vol2" {
      + access_mode            = "ReadOnly"
      + capacity_unit          = "GB"
      + compression_method     = (known after apply)
      + id                     = (known after apply)
      + name                   = "sdc_map_test_rounak_3"
      + protection_domain_id   = (known after apply)
      + protection_domain_name = "domain1"
      + remove_mode            = "ONLY_ME"
      + sdc_list               = [
        ]
      + size                   = 16
      + size_in_kb             = 16777216
      + storage_pool_id        = (known after apply)
      + storage_pool_name      = "pool1"
      + use_rm_cache           = (known after apply)
      + volume_type            = "ThinProvisioned"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
powerflex_volume.vol1: Creating...
powerflex_volume.vol2: Creating...
powerflex_volume.vol1: Creation complete after 1s [id=edb3db0d00000007]
powerflex_volume.vol2: Creation complete after 1s [id=edb3db0e00000008]
powerflex_snapshot.ss: Creating...
powerflex_snapshot.ss: Creation complete after 0s [id=edb3db0f00000009]
powerflex_sdc_volumes_mapping.mapping-test: Creating...
powerflex_sdc_volumes_mapping.mapping-test: Creation complete after 1s [id=e3ce46c500000002]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
root@lglap049:~/test-tf# 
root@lglap049:~/test-tf# 
root@lglap049:~/test-tf# 
root@lglap049:~/test-tf# 

# Changing only names of volume --------------------------------------------------------------------------------
# Notice that the sdc_list is being planned to be null

root@lglap049:~/test-tf# terraform apply
powerflex_volume.vol1: Refreshing state... [id=edb3db0d00000007]
powerflex_volume.vol2: Refreshing state... [id=edb3db0e00000008]
powerflex_snapshot.ss: Refreshing state... [id=edb3db0f00000009]
powerflex_sdc_volumes_mapping.mapping-test: Refreshing state... [id=e3ce46c500000002]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # powerflex_volume.vol2 will be updated in-place
  ~ resource "powerflex_volume" "vol2" {
        id                     = "edb3db0e00000008"
      ~ name                   = "sdc_map_test_rounak_3" -> "sdc_map_test_rounak_32"
      ~ sdc_list               = [
          - {
              - access_mode      = "ReadOnly" -> null
              - limit_bw_in_mbps = 20 -> null
              - limit_iops       = 141 -> null
              - sdc_id           = "e3ce46c500000002" -> null
              - sdc_name         = "Terraform_sdc2" -> null
            },
        ]
      ~ use_rm_cache           = false -> (known after apply)
        # (11 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

powerflex_volume.vol2: Modifying... [id=edb3db0e00000008]
powerflex_volume.vol2: Modifications complete after 0s [id=edb3db0e00000008]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

# Now sdc_list resource is complaining as one volume has been unmapped from sdc -----------------------------------

root@lglap049:~/test-tf# terraform apply
powerflex_volume.vol2: Refreshing state... [id=edb3db0e00000008]
powerflex_volume.vol1: Refreshing state... [id=edb3db0d00000007]
powerflex_snapshot.ss: Refreshing state... [id=edb3db0f00000009]
powerflex_sdc_volumes_mapping.mapping-test: Refreshing state... [id=e3ce46c500000002]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # powerflex_sdc_volumes_mapping.mapping-test will be updated in-place
  ~ resource "powerflex_sdc_volumes_mapping" "mapping-test" {
        id          = "e3ce46c500000002"
        name        = "Terraform_sdc2"
      ~ volume_list = [
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 20
              + limit_iops       = 141
              + volume_id        = "edb3db0e00000008"
              + volume_name      = "sdc_map_test_rounak_32"
            },
            # (2 unchanged elements hidden)
        ]
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

powerflex_sdc_volumes_mapping.mapping-test: Modifying... [id=e3ce46c500000002]
powerflex_sdc_volumes_mapping.mapping-test: Modifications complete after 0s [id=e3ce46c500000002]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
root@lglap049:~/test-tf# 
```


Now ==========

```

# Creating all volumes and mappings ----------------

root@lglap049:~/test-tf# terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # powerflex_sdc_volumes_mapping.mapping-test will be created
  + resource "powerflex_sdc_volumes_mapping" "mapping-test" {
      + id          = "e3ce46c500000002"
      + name        = "Terraform_sdc2"
      + volume_list = [
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 19
              + limit_iops       = 140
              + volume_id        = (known after apply)
              + volume_name      = (known after apply)
            },
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 20
              + limit_iops       = 141
              + volume_id        = (known after apply)
              + volume_name      = (known after apply)
            },
          + {
              + access_mode      = "ReadOnly"
              + limit_bw_in_mbps = 20
              + limit_iops       = 141
              + volume_id        = (known after apply)
              + volume_name      = (known after apply)
            },
        ]
    }

  # powerflex_snapshot.ss will be created
  + resource "powerflex_snapshot" "ss" {
      + access_mode        = "ReadOnly"
      + capacity_unit      = "GB"
      + id                 = (known after apply)
      + lock_auto_snapshot = (known after apply)
      + name               = "sdc_map_test_ss_rounak_1"
      + remove_mode        = "ONLY_ME"
      + retention_unit     = "hours"
      + sdc_list           = [
        ] -> (known after apply)
      + size               = (known after apply)
      + size_in_kb         = (known after apply)
      + volume_id          = (known after apply)
      + volume_name        = (known after apply)
    }

  # powerflex_volume.vol1 will be created
  + resource "powerflex_volume" "vol1" {
      + access_mode            = "ReadOnly"
      + capacity_unit          = "GB"
      + compression_method     = (known after apply)
      + id                     = (known after apply)
      + name                   = "sdc_map_test_rounak_12"
      + protection_domain_id   = (known after apply)
      + protection_domain_name = "domain1"
      + remove_mode            = "ONLY_ME"
      + sdc_list               = [
        ] -> (known after apply)
      + size                   = 8
      + size_in_kb             = 8388608
      + storage_pool_id        = (known after apply)
      + storage_pool_name      = "pool1"
      + use_rm_cache           = (known after apply)
      + volume_type            = "ThinProvisioned"
    }

  # powerflex_volume.vol2 will be created
  + resource "powerflex_volume" "vol2" {
      + access_mode            = "ReadOnly"
      + capacity_unit          = "GB"
      + compression_method     = (known after apply)
      + id                     = (known after apply)
      + name                   = "sdc_map_test_rounak_3"
      + protection_domain_id   = (known after apply)
      + protection_domain_name = "domain1"
      + remove_mode            = "ONLY_ME"
      + sdc_list               = [
        ] -> (known after apply)
      + size                   = 16
      + size_in_kb             = 16777216
      + storage_pool_id        = (known after apply)
      + storage_pool_name      = "pool1"
      + use_rm_cache           = (known after apply)
      + volume_type            = "ThinProvisioned"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
powerflex_volume.vol2: Creating...
powerflex_volume.vol1: Creating...
powerflex_volume.vol2: Creation complete after 0s [id=edb3dae400000007]
powerflex_volume.vol1: Creation complete after 0s [id=edb3dae500000008]
powerflex_snapshot.ss: Creating...
powerflex_snapshot.ss: Creation complete after 0s [id=edb3dae600000009]
powerflex_sdc_volumes_mapping.mapping-test: Creating...
powerflex_sdc_volumes_mapping.mapping-test: Creation complete after 0s [id=e3ce46c500000002]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
root@lglap049:~/test-tf# 
root@lglap049:~/test-tf# 

# Changing volume and snapshot names -----------------------------------------------------------
# Notice that the sdc_list is set to unknown --------------------------------------------------------

root@lglap049:~/test-tf# terraform apply --auto-approve
powerflex_volume.vol2: Refreshing state... [id=edb3dae400000007]
powerflex_volume.vol1: Refreshing state... [id=edb3dae500000008]
powerflex_snapshot.ss: Refreshing state... [id=edb3dae600000009]
powerflex_sdc_volumes_mapping.mapping-test: Refreshing state... [id=e3ce46c500000002]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # powerflex_snapshot.ss will be updated in-place
  ~ resource "powerflex_snapshot" "ss" {
        id                 = "edb3dae600000009"
      ~ name               = "sdc_map_test_ss_rounak_1" -> "sdc_map_test_ss_rounak_12"
      ~ sdc_list           = [
          - {
              - access_mode      = "ReadOnly" -> null
              - limit_bw_in_mbps = 19 -> null
              - limit_iops       = 140 -> null
              - sdc_id           = "e3ce46c500000002" -> null
              - sdc_name         = "Terraform_sdc2" -> null
            },
        ] -> (known after apply)
      ~ size               = 16 -> (known after apply)
      ~ size_in_kb         = 16777216 -> (known after apply)
        # (7 unchanged attributes hidden)
    }

  # powerflex_volume.vol1 will be updated in-place
  ~ resource "powerflex_volume" "vol1" {
        id                     = "edb3dae500000008"
      ~ name                   = "sdc_map_test_rounak_12" -> "sdc_map_test_rounak_1"
      ~ sdc_list               = [
          - {
              - access_mode      = "ReadOnly" -> null
              - limit_bw_in_mbps = 20 -> null
              - limit_iops       = 141 -> null
              - sdc_id           = "e3ce46c500000002" -> null
              - sdc_name         = "Terraform_sdc2" -> null
            },
        ] -> (known after apply)
      ~ use_rm_cache           = false -> (known after apply)
        # (11 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
powerflex_volume.vol1: Modifying... [id=edb3dae500000008]
powerflex_snapshot.ss: Modifying... [id=edb3dae600000009]
powerflex_volume.vol1: Modifications complete after 0s [id=edb3dae500000008]
powerflex_snapshot.ss: Modifications complete after 0s [id=edb3dae600000009]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
root@lglap049:~/test-tf# 
root@lglap049:~/test-tf# 

# Notice that sdc_list resource is no longer complaining as no unmappings have happened ----------------

root@lglap049:~/test-tf# terraform apply --auto-approve
powerflex_volume.vol1: Refreshing state... [id=edb3dae500000008]
powerflex_volume.vol2: Refreshing state... [id=edb3dae400000007]
powerflex_snapshot.ss: Refreshing state... [id=edb3dae600000009]
powerflex_sdc_volumes_mapping.mapping-test: Refreshing state... [id=e3ce46c500000002]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
root@lglap049:~/test-tf#
```