### PR TITLE
Unit Test Setup

### DIFF
--- a/powerflex/provider/clutser_resource.go
+++ b/powerflex/provider/clutser_resource.go
@@ -492,7 +492,7 @@ func (r *clusterResource) ClusterDeploymentOperations(ctx context.Context, plan 
 
 	if parseCSVError != nil {
 		dia.AddError(
-			"Error while Parsing CSV",
+			"Error During Installation, Error while Parsing CSV",
 			"unexpected error: "+parseCSVError.Error(),
 		)
 		return

--- a/powerflex/provider/provider_test.go
+++ b/powerflex/provider/provider_test.go
@@ -84,25 +84,25 @@ func getNewSdsDataPointForTest() sdsDataPoints {
 		log.Fatal("Error loading .env file: ", err)
 		return SdsResourceTestData
 	}
-	SdsResourceTestData.SdsIP1 = os.Getenv("POWERFLEX_SDS_IP_1")
-	SdsResourceTestData.SdsIP2 = os.Getenv("POWERFLEX_SDS_IP_2")
-	SdsResourceTestData.SdsIP3 = os.Getenv("POWERFLEX_SDS_IP_3")
-	SdsResourceTestData.SdsIP4 = os.Getenv("POWERFLEX_SDS_IP_4")
-	SdsResourceTestData.SdsIP5 = os.Getenv("POWERFLEX_SDS_IP_5")
-	SdsResourceTestData.SdsIP6 = os.Getenv("POWERFLEX_SDS_IP_6")
-	SdsResourceTestData.SdsIP7 = os.Getenv("POWERFLEX_SDS_IP_7")
-	SdsResourceTestData.SdsIP8 = os.Getenv("POWERFLEX_SDS_IP_8")
-	SdsResourceTestData.SdsIP9 = os.Getenv("POWERFLEX_SDS_IP_9")
-	SdsResourceTestData.SdsIP10 = os.Getenv("POWERFLEX_SDS_IP_10")
-	SdsResourceTestData.SdsIP11 = os.Getenv("POWERFLEX_SDS_IP_11")
-	SdsResourceTestData.SdcIP = os.Getenv("POWERFLEX_SDC_IP")
-	SdsResourceTestData.SdcIP1 = os.Getenv("POWERFLEX_SDC_IP1")
-	SdsResourceTestData.volName = os.Getenv("POWERFLEX_VOLUME_NAME")
-	SdsResourceTestData.volName2 = os.Getenv("POWERFLEX_VOLUME_NAME_2")
-	SdsResourceTestData.volName3 = os.Getenv("POWERFLEX_VOLUME_NAME_3")
-	SdsResourceTestData.sdcName = os.Getenv("POWERFLEX_SDC_NAME")
-	SdsResourceTestData.sdcName2 = os.Getenv("POWERFLEX_SDC_NAME_2")
-	SdsResourceTestData.sdcName3 = os.Getenv("POWERFLEX_SDC_NAME_3")
+	SdsResourceTestData.SdsIP1 = setDefault(os.Getenv("POWERFLEX_SDS_IP_1"), "tfacc_sds_1")
+	SdsResourceTestData.SdsIP2 = setDefault(os.Getenv("POWERFLEX_SDS_IP_2"), "tfacc_sds_2")
+	SdsResourceTestData.SdsIP3 = setDefault(os.Getenv("POWERFLEX_SDS_IP_3"), "tfacc_sds_3")
+	SdsResourceTestData.SdsIP4 = setDefault(os.Getenv("POWERFLEX_SDS_IP_4"), "tfacc_sds_4")
+	SdsResourceTestData.SdsIP5 = setDefault(os.Getenv("POWERFLEX_SDS_IP_5"), "tfacc_sds_5")
+	SdsResourceTestData.SdsIP6 = setDefault(os.Getenv("POWERFLEX_SDS_IP_6"), "tfacc_sds_6")
+	SdsResourceTestData.SdsIP7 = setDefault(os.Getenv("POWERFLEX_SDS_IP_7"), "tfacc_sds_7")
+	SdsResourceTestData.SdsIP8 = setDefault(os.Getenv("POWERFLEX_SDS_IP_8"), "tfacc_sds_8")
+	SdsResourceTestData.SdsIP9 = setDefault(os.Getenv("POWERFLEX_SDS_IP_9"), "tfacc_sds_9")
+	SdsResourceTestData.SdsIP10 = setDefault(os.Getenv("POWERFLEX_SDS_IP_10"), "tfacc_sds_10")
+	SdsResourceTestData.SdsIP11 = setDefault(os.Getenv("POWERFLEX_SDS_IP_11"), "tfacc_sds_11")
+	SdsResourceTestData.SdcIP = setDefault(os.Getenv("POWERFLEX_SDC_IP"), "tfacc_sdc_ip_1")
+	SdsResourceTestData.SdcIP1 = setDefault(os.Getenv("POWERFLEX_SDC_IP1"), "tfacc_sdc_ip_2")
+	SdsResourceTestData.volName = setDefault(os.Getenv("POWERFLEX_VOLUME_NAME"), "tfacc_volume_1")
+	SdsResourceTestData.volName2 = setDefault(os.Getenv("POWERFLEX_VOLUME_NAME_2"), "tfacc_volume_2")
+	SdsResourceTestData.volName3 = setDefault(os.Getenv("POWERFLEX_VOLUME_NAME_3"), "tfacc_volume_3")
+	SdsResourceTestData.sdcName = setDefault(os.Getenv("POWERFLEX_SDC_NAME"), "tfacc_sdc_name_1")
+	SdsResourceTestData.sdcName2 = setDefault(os.Getenv("POWERFLEX_SDC_NAME_2"), "tfacc_sdc_name_2")
+	SdsResourceTestData.sdcName3 = setDefault(os.Getenv("POWERFLEX_SDC_NAME_3"), "tfacc_sdc_name_3")
 
 	return SdsResourceTestData
 }
@@ -117,16 +117,16 @@ func getNewGatewayDataPointForTest() gatewayDataPoints {
 		return GatewayDataPoints
 	}
 
-	GatewayDataPoints.primaryMDMIP = os.Getenv("POWERFLEX_PRIMARY_MDM_IP")
-	GatewayDataPoints.secondaryMDMIP = os.Getenv("POWERFLEX_SECONDARY_MDM_IP")
-	GatewayDataPoints.tbIP = os.Getenv("POWERFLEX_TB_IP")
-	GatewayDataPoints.sdcServerIP = os.Getenv("POWERFLEX_SDC_SERVER_IP")
-	GatewayDataPoints.serverPassword = os.Getenv("POWERFLEX_SERVER_PASSWORD")
-	GatewayDataPoints.mdmPassword = os.Getenv("POWERFLEX_MDM_PASSWORD")
-	GatewayDataPoints.liaPassword = os.Getenv("POWERFLEX_LIA_PASSWORD")
-	GatewayDataPoints.clusterPrimaryIP = os.Getenv("POWERFLEX_CLUSTER_IP_1")
-	GatewayDataPoints.clusterSecondaryIP = os.Getenv("POWERFLEX_CLUSTER_IP_2")
-	GatewayDataPoints.clusterTBIP = os.Getenv("POWERFLEX_CLUSTER_IP_3")
+	GatewayDataPoints.primaryMDMIP = setDefault(os.Getenv("POWERFLEX_PRIMARY_MDM_IP"), "tfacc_primary_mdm_ip")
+	GatewayDataPoints.secondaryMDMIP = setDefault(os.Getenv("POWERFLEX_SECONDARY_MDM_IP"), "tfacc_secondary_mdm_ip")
+	GatewayDataPoints.tbIP = setDefault(os.Getenv("POWERFLEX_TB_IP"), "tfacc_tb_ip")
+	GatewayDataPoints.sdcServerIP = setDefault(os.Getenv("POWERFLEX_SDC_SERVER_IP"), "tfacc_sdc_server_ip")
+	GatewayDataPoints.serverPassword = setDefault(os.Getenv("POWERFLEX_SERVER_PASSWORD"), "tfacc_server_password")
+	GatewayDataPoints.mdmPassword = setDefault(os.Getenv("POWERFLEX_MDM_PASSWORD"), "tfacc_mdm_password")
+	GatewayDataPoints.liaPassword = setDefault(os.Getenv("POWERFLEX_LIA_PASSWORD"), "tfacc_lia_password")
+	GatewayDataPoints.clusterPrimaryIP = setDefault(os.Getenv("POWERFLEX_CLUSTER_IP_1"), "tfacc_cluster_ip_1")
+	GatewayDataPoints.clusterSecondaryIP = setDefault(os.Getenv("POWERFLEX_CLUSTER_IP_2"), "tfacc_cluster_ip_2")
+	GatewayDataPoints.clusterTBIP = setDefault(os.Getenv("POWERFLEX_CLUSTER_IP_3"), "tfacc_cluster_ip_3")
 
 	return GatewayDataPoints
 }
@@ -141,26 +141,29 @@ func getMdmDataPointsForTest() mdmDataPoints {
 		return MDMDataPoints
 	}
 
-	MDMDataPoints.primaryMDMIP = os.Getenv("POWERFLEX_PRIMARY_MDM_IP")
-	MDMDataPoints.secondaryMDMIP = os.Getenv("POWERFLEX_SECONDARY_MDM_IP")
-	MDMDataPoints.tbIP = os.Getenv("POWERFLEX_TB_IP")
-	MDMDataPoints.primaryMDMID = os.Getenv("POWERFLEX_PRIMARY_MDM_ID")
-	MDMDataPoints.secondaryMDMID = os.Getenv("POWERFLEX_SECONDARY_MDM_ID")
-	MDMDataPoints.tbID = os.Getenv("POWERFLEX_TB_ID")
-	MDMDataPoints.standByIP1 = os.Getenv("POWERFLEX_STANDBY_MDM_IP1")
-	MDMDataPoints.standByIP2 = os.Getenv("POWERFLEX_STANDBY_MDM_IP2")
+	MDMDataPoints.primaryMDMIP = setDefault(os.Getenv("POWERFLEX_PRIMARY_MDM_IP"), "tfacc_primary_mdm_ip")
+	MDMDataPoints.secondaryMDMIP = setDefault(os.Getenv("POWERFLEX_SECONDARY_MDM_IP"), "tfacc_secondary_mdm_ip")
+	MDMDataPoints.tbIP = setDefault(os.Getenv("POWERFLEX_TB_IP"), "tfacc_tb_ip")
+	MDMDataPoints.primaryMDMID = setDefault(os.Getenv("POWERFLEX_PRIMARY_MDM_ID"), "tfacc_primary_mdm_id")
+	MDMDataPoints.secondaryMDMID = setDefault(os.Getenv("POWERFLEX_SECONDARY_MDM_ID"), "tfacc_secondary_mdm_id")
+	MDMDataPoints.tbID = setDefault(os.Getenv("POWERFLEX_TB_ID"), "tfacc_tb_id")
+	MDMDataPoints.standByIP1 = setDefault(os.Getenv("POWERFLEX_STANDBY_MDM_IP1"), "1.1.1.1")
+	MDMDataPoints.standByIP2 = setDefault(os.Getenv("POWERFLEX_STANDBY_MDM_IP2"), "1.1.1.2")
 
 	return MDMDataPoints
 }
 
 var SdsResourceTestData = getNewSdsDataPointForTest()
 var GatewayDataPoints = getNewGatewayDataPointForTest()
-var SDCMappingResourceID2 = os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_ID2")
-var SDCMappingResourceName2 = os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_NAME2")
-var SDCVolName = os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_NAME")
-var SdsID = os.Getenv("POWERFLEX_DEVICE_SDS_ID")
+var SDCMappingResourceID2 = setDefault(os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_ID2"), "tfacc_sdc_volumes_mapping_id2")
+var SDCMappingResourceName2 = setDefault(os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_NAME2"), "tfacc_sdc_volumes_mapping_name2")
+var SDCVolName = setDefault(os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_NAME"), "tfacc_sdc_volumes_mapping_name")
+var SdsID = setDefault(os.Getenv("POWERFLEX_DEVICE_SDS_ID"), "tfacc_device_sds_id")
 var MDMDataPoints = getMdmDataPointsForTest()
-var ProtectionDomainID = os.Getenv("POWERFLEX_PROTECTION_DOMAIN_ID")
+var ProtectionDomainID = setDefault(os.Getenv("POWERFLEX_PROTECTION_DOMAIN_ID"), "tfacc_protection_domain_id")
+var username = setDefault(os.Getenv("POWERFLEX_USERNAME"), "test")
+var password = setDefault(os.Getenv("POWERFLEX_PASSWORD"), "test")
+var endpoint = setDefault(os.Getenv("POWERFLEX_ENDPOINT"), "http://localhost:3002")
 
 func init() {
 	err := godotenv.Load("powerflex.env")
@@ -168,10 +171,6 @@ func init() {
 		log.Fatal("Error loading .env file: ", err)
 		return
 	}
-
-	username := os.Getenv("POWERFLEX_USERNAME")
-	password := os.Getenv("POWERFLEX_PASSWORD")
-	endpoint := os.Getenv("POWERFLEX_ENDPOINT")
 
 	ProviderConfigForTesting = fmt.Sprintf(`
 		provider "powerflex" {
@@ -193,15 +192,23 @@ var (
 )
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("POWERFLEX_USERNAME"); v == "" {
+	if v := username; v == "" {
 		t.Fatal("POWERFLEX_USERNAME must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("POWERFLEX_PASSWORD"); v == "" {
+	if v := password; v == "" {
 		t.Fatal("POWERFLEX_PASSWORD must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("POWERFLEX_ENDPOINT"); v == "" {
+	if v := endpoint; v == "" {
 		t.Fatal("POWERFLEX_ENDPOINT must be set for acceptance tests")
 	}
+}
+
+// if there is no os setting set, then use the default value
+func setDefault(osInput string, defaultStr string) string {
+	if osInput == "" {
+		return defaultStr
+	}
+	return osInput
 }


### PR DESCRIPTION
# Description
- Add Defaults for the tests if the user does not set through os env variables. These are the values used in the mock server.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test

Test Output
```
$ TF_ACC=1 go test -v -timeout 1h -run TestAccDeviceDatasource
=== RUN   TestAccDeviceDatasource
--- PASS: TestAccDeviceDatasource (64.77s)
=== RUN   TestAccDeviceDatasourcePDC
--- PASS: TestAccDeviceDatasourcePDC (3.55s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 69.297s

$ TF_ACC=1 go test -v -timeout 1h -run TestAccFaultSetDataSource
=== RUN   TestAccFaultSetDataSource
--- PASS: TestAccFaultSetDataSource (24.37s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 25.247s


$ TF_ACC=1 go test -v -timeout 1h -run TestAccProtectionDomainDataSource
=== RUN   TestAccProtectionDomainDataSource
--- PASS: TestAccProtectionDomainDataSource (20.56s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 21.257s

$ TF_ACC=1 go test -v -timeout 1h -run TestSdcDataSource
=== RUN   TestSdcDataSource
--- PASS: TestSdcDataSource (19.96s)
=== RUN   TestSdcDataSourceNegative
--- PASS: TestSdcDataSourceNegative (3.52s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 24.156s

$ TF_ACC=1 go test -v -timeout 1h -run TestSdsDataSource
=== RUN   TestSdsDataSource
--- PASS: TestSdsDataSource (35.33s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 36.002s

 TF_ACC=1 go test -v -timeout 1h -run TestAccSnapshotPolicyDataSource
=== RUN   TestAccSnapshotPolicyDataSource
--- PASS: TestAccSnapshotPolicyDataSource (20.69s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 21.398s

$ TF_ACC=1 go test -v -timeout 1h -run TestStoragePoolDataSource
=== RUN   TestStoragePoolDataSource
--- PASS: TestStoragePoolDataSource (35.57s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 36.291s

$ TF_ACC=1 go test -v -timeout 1h -run TestAccVolumeDataSource
=== RUN   TestAccVolumeDataSource
[FindVolumeID] volumeID: tfaccp-ssvol-test
[FindVolumeID] volumeID: tfaccp-ssvol-test
[FindVolumeID] volumeID: tfaccp-ssvol-test
[FindVolumeID] volumeID: tfaccp-ssvol-test
[FindVolumeID] volumeID: tfaccp-ssvol-test
--- PASS: TestAccVolumeDataSource (33.58s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 34.262s

$ TF_ACC=1 go test -v -timeout 1h -run TestAccVTreeDataSource
=== RUN   TestAccVTreeDataSource
[FindVolumeID] volumeID: terraform-vol-vtree-datasource
[FindVolumeID] volumeID: terraform-vol-vtree-datasource1
[FindVolumeID] volumeID: terraform-vol-vtree-datasource
[FindVolumeID] volumeID: terraform-vol-vtree-datasource1
[FindVolumeID] volumeID: terraform-vol-vtree-datasource
[FindVolumeID] volumeID: terraform-vol-vtree-datasource1
[FindVolumeID] volumeID: terraform-vol-vtree-datasource
[FindVolumeID] volumeID: terraform-vol-vtree-datasource1
[FindVolumeID] volumeID: terraform-vol-vtree-datasource
[FindVolumeID] volumeID: terraform-vol-vtree-datasource1
[FindVolumeID] volumeID: invalid
--- PASS: TestAccVTreeDataSource (42.50s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 43.280s
```