### PR TITLE
Update Device Resource Tests for unit testing

### DIFF
--- a/powerflex/provider/device_resource_test.go
+++ b/powerflex/provider/device_resource_test.go
@@ -33,7 +33,7 @@ var createSDSForTest = `
 				role = "all"
 			}
 		]
-		protection_domain_id = "` + protectionDomainID1 + `"
+		protection_domain_id = "` + ProtectionDomainID + `"
 	}
 	`
 
@@ -73,11 +73,11 @@ func TestAccDeviceResourceWithSPID(t *testing.T) {
 }
 
 func TestAccDeviceResourceWithSPName(t *testing.T) {
-	var AddDeviceWithSPName = createSDSForTest + `
+	var AddDeviceWithSPName = createSDSForTest + createStoragePool + `
 	resource "powerflex_device" "device-test" {
 		name = "terraform-device"
 		device_path = "/dev/sdc"
-		storage_pool_name = "pool1"
+		storage_pool_name = resource.powerflex_storage_pool.pre-req1.name
 		protection_domain_name = "domain1"
 		sds_id = powerflex_sds.sds.id
 		media_type = "HDD"
@@ -92,7 +92,7 @@ func TestAccDeviceResourceWithSPName(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "device_path", "/dev/sdc"),
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "name", "terraform-device"),
-					resource.TestCheckResourceAttr("powerflex_device.device-test", "storage_pool_name", "pool1"),
+					resource.TestCheckResourceAttr("powerflex_device.device-test", "storage_pool_name", "terraform-storage-pool"),
 					resource.TestCheckResourceAttrPair("powerflex_device.device-test", "sds_id", "powerflex_sds.sds", "id"),
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "media_type", "HDD"),
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "protection_domain_name", "domain1"),
@@ -102,12 +102,12 @@ func TestAccDeviceResourceWithSPName(t *testing.T) {
 }
 
 func TestAccDeviceResourceWithPDID(t *testing.T) {
-	var AddDeviceWithSPName = createSDSForTest + `
+	var AddDeviceWithSPName = createSDSForTest + createStoragePool + `
 	resource "powerflex_device" "device-test" {
 		name = "terraform-device"
 		device_path = "/dev/sdc"
-		storage_pool_name = "pool1"
-		protection_domain_id = "202a046600000000"
+		storage_pool_name =  resource.powerflex_storage_pool.pre-req1.name
+		protection_domain_id = "` + ProtectionDomainID + `"
 		sds_id = powerflex_sds.sds.id
 		media_type = "HDD"
 	 }
@@ -121,10 +121,10 @@ func TestAccDeviceResourceWithPDID(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "device_path", "/dev/sdc"),
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "name", "terraform-device"),
-					resource.TestCheckResourceAttr("powerflex_device.device-test", "storage_pool_name", "pool1"),
+					resource.TestCheckResourceAttr("powerflex_device.device-test", "storage_pool_name", "terraform-storage-pool"),
 					resource.TestCheckResourceAttrPair("powerflex_device.device-test", "sds_id", "powerflex_sds.sds", "id"),
 					resource.TestCheckResourceAttr("powerflex_device.device-test", "media_type", "HDD"),
-					resource.TestCheckResourceAttr("powerflex_device.device-test", "protection_domain_id", "202a046600000000"),
+					resource.TestCheckResourceAttr("powerflex_device.device-test", "protection_domain_id", ProtectionDomainID),
 				),
 			},
 		}})
@@ -159,7 +159,7 @@ func TestAccDeviceResourceWithSDSName(t *testing.T) {
 func TestAccDeviceNegative(t *testing.T) {
 	var InvalidPath = createStoragePool + `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_id = resource.powerflex_storage_pool.pre-req1.id
 		sds_name = "SDS_2"
@@ -169,7 +169,7 @@ func TestAccDeviceNegative(t *testing.T) {
 
 	var InvalidConfigWOPD = `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_name = "akash-pool"
 		sds_name = "SDS_2"
@@ -179,7 +179,7 @@ func TestAccDeviceNegative(t *testing.T) {
 
 	var InvalidPD = `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_name = "akash-pool"
 		protection_domain_name = "invalid"
@@ -190,7 +190,7 @@ func TestAccDeviceNegative(t *testing.T) {
 
 	var InvalidSPID = `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_id = "invalid"
 		sds_name = "SDS_2"
@@ -200,7 +200,7 @@ func TestAccDeviceNegative(t *testing.T) {
 
 	var InvalidSPName = `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_name = "invalid"
 		protection_domain_name = "domain1"
@@ -211,7 +211,7 @@ func TestAccDeviceNegative(t *testing.T) {
 
 	var InvalidSDSID = createStoragePool + `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_id = resource.powerflex_storage_pool.pre-req1.id
 		sds_id = "invalid"
@@ -221,7 +221,7 @@ func TestAccDeviceNegative(t *testing.T) {
 
 	var InvalidSDSName = createStoragePool + `
 	resource "powerflex_device" "device-test" {
-		name = "terraform-device"
+		name = "terraform-device-invalid"
 		device_path = "/dev/sdd"
 		storage_pool_id = resource.powerflex_storage_pool.pre-req1.id
 		sds_name = "invalid"

--- a/powerflex/provider/provider_test.go
+++ b/powerflex/provider/provider_test.go
@@ -160,6 +160,7 @@ var SDCMappingResourceName2 = setDefault(os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPIN
 var SDCVolName = setDefault(os.Getenv("POWERFLEX_SDC_VOLUMES_MAPPING_NAME"), "tfacc_sdc_volumes_mapping_name")
 var SdsID = setDefault(os.Getenv("POWERFLEX_DEVICE_SDS_ID"), "tfacc_device_sds_id")
 var MDMDataPoints = getMdmDataPointsForTest()
+var StoragePoolName = setDefault(os.Getenv("POWERFLEX_STORAGE_POOL_NAME"), "tfacc_storage_pool_name")
 var ProtectionDomainID = setDefault(os.Getenv("POWERFLEX_PROTECTION_DOMAIN_ID"), "tfacc_protection_domain_id")
 var username = setDefault(os.Getenv("POWERFLEX_USERNAME"), "test")
 var password = setDefault(os.Getenv("POWERFLEX_PASSWORD"), "test")

--- a/powerflex/provider/storagepool_resource_test.go
+++ b/powerflex/provider/storagepool_resource_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-var testAccStoragePoolName = os.Getenv("POWERFLEX_STORAGE_POOL_NAME")
+var testAccStoragePoolName = StoragePoolName
 
 // TestAccStoragepoolResource
 func TestAccStoragepoolResource(t *testing.T) {


### PR DESCRIPTION
  - Seperate name for invalid device test
  - Use global ProtectionDomainID

# Description
Make some modifications for Device resource unit testing

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 80% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test
![Device1](https://github.com/dell/terraform-provider-powerflex/assets/131491094/4a775767-afd9-40f4-b202-09256aa4ab65)
![devide7](https://github.com/dell/terraform-provider-powerflex/assets/131491094/e379283f-4061-4d3c-abf2-fa617c43dfdf)
![Device6](https://github.com/dell/terraform-provider-powerflex/assets/131491094/3f68fbc2-70e7-4f73-ad05-ee08bb827321)
![Device5](https://github.com/dell/terraform-provider-powerflex/assets/131491094/1405bcdf-4b6b-4af7-ad24-8c6e75c2372c)
![Device4](https://github.com/dell/terraform-provider-powerflex/assets/131491094/28e0d790-77d7-4928-8db9-66b12940ee0d)
![Device3](https://github.com/dell/terraform-provider-powerflex/assets/131491094/2f3d36e6-8f34-4d80-91ca-deca26316f9f)
![Device2](https://github.com/dell/terraform-provider-powerflex/assets/131491094/0516871e-33db-4a32-b31d-e87772e84e44)
