### PR TITLE
Fix: Move duplicate IP validation to Create/Update phase to cover unknown IPs

### DIFF
--- a/powerflex/provider/sds_resource_test.go
+++ b/powerflex/provider/sds_resource_test.go
@@ -284,6 +284,11 @@ func TestAccSDSResourceDuplicateIP(t *testing.T) {
 					resource.TestCheckResourceAttr("powerflex_sds.sds", "ip_list.#", "3"),
 				),
 			},
+			// modify sds test invalid
+			{
+				Config:      ProviderConfigForTesting + createSDSTestManyInValid,
+				ExpectError: regexp.MustCompile(`.*The IP .* is configured with .*roles.*`),
+			},
 		},
 	})
 }


### PR DESCRIPTION
# Description
Move duplicate IP validation to Create/Update phasee to cover unknown IPs.
Earlier, validation happened at the "ValidateConfig" phase, and if there were multiple unknown IPs, they were treated as the same IP.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

1. Ran functional tests on pflex version 3.6
2. Ran Acceptance test on pflex 3.6
```
root@lglap049:~/terraform-provider-powerflex# go test ./powerflex/provider/ -v -timeout 5h -run SDSRes -count=1 -coverprofile cover1.out
=== RUN   TestAccSDSResource
--- PASS: TestAccSDSResource (19.35s)
=== RUN   TestAccSDSResourceDuplicateIP
--- PASS: TestAccSDSResourceDuplicateIP (6.95s)
=== RUN   TestAccSDSResourceRmCache
--- PASS: TestAccSDSResourceRmCache (15.78s)
=== RUN   TestAccSDSResourceCreateWithoutIP
--- PASS: TestAccSDSResourceCreateWithoutIP (0.21s)
=== RUN   TestAccSDSResourceCreateWithBadRole
--- PASS: TestAccSDSResourceCreateWithBadRole (0.24s)
=== RUN   TestAccSDSResourceCreateWithBadPerformanceProfile
--- PASS: TestAccSDSResourceCreateWithBadPerformanceProfile (0.23s)
=== RUN   TestAccSDSResourceCreateWithoutPD
--- PASS: TestAccSDSResourceCreateWithoutPD (0.22s)
=== RUN   TestAccSDSResourceCreateWithoutName
--- PASS: TestAccSDSResourceCreateWithoutName (0.24s)
=== RUN   TestSDSResourceCreateNegative
--- PASS: TestSDSResourceCreateNegative (6.95s)
=== RUN   TestSDSResourceCreateSpecialChar
--- PASS: TestSDSResourceCreateSpecialChar (4.63s)
=== RUN   TestSDSResourceCreateMandatoryParams
--- PASS: TestSDSResourceCreateMandatoryParams (7.14s)
=== RUN   TestSDSResourceModifyRole
--- PASS: TestSDSResourceModifyRole (14.20s)
=== RUN   TestSDSResourceModifyRoleAddIP
--- PASS: TestSDSResourceModifyRoleAddIP (20.15s)
=== RUN   TestSDSResourceAddIP
--- PASS: TestSDSResourceAddIP (12.84s)
=== RUN   TestSDSResourceRemoveIP
--- PASS: TestSDSResourceRemoveIP (12.44s)
=== RUN   TestSDSResourceModifyInvalid
--- PASS: TestSDSResourceModifyInvalid (8.74s)
=== RUN   TestSDSResourceRename
--- PASS: TestSDSResourceRename (9.75s)
=== RUN   TestSDSResoureUpdateProtectionDomainIDNegative
--- PASS: TestSDSResoureUpdateProtectionDomainIDNegative (5.73s)
=== RUN   TestSDSResoureUpdateProtectionDomainName
--- PASS: TestSDSResoureUpdateProtectionDomainName (11.39s)
PASS
coverage: 13.8% of statements
ok      terraform-provider-powerflex/powerflex/provider 157.256s        coverage: 13.8% of statements
root@lglap049:~/terraform-provider-powerflex#
```

Coverage:
![image](https://github.com/dell/terraform-provider-powerflex/assets/120458947/1a8f5596-6c32-40ef-83a6-dd70db7694b2)


