### PR TITLE
adding example of user resource for different powerflex versions

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -50,13 +50,31 @@ limitations under the License.
 # Create, Update, Delete is supported for this resource
 # Import is supported.
 
-# Example for creating user. After successful execution, user will be created with Monitor role.
+# Example for creating user. After successful execution, user will be created with Monitor role. Below example works for PowerFlex version 3.6.
 resource "powerflex_user" "newUser" {
 
   # name, role and password is the required parameter to create or update. Only role can be updated.
-  name     = "StorageAdmin"
+  name     = "terraform"
   role     = "Monitor" # Administrator/Monitor/Configure/Security/FrontendConfig/BackendConfig
   password = "Password"
+}
+
+# Example for creating user. After successful execution, user will be created with SystemAdmin role. Below example works for PowerFlex version 4.5.
+resource "powerflex_user" "newUser" {
+
+  # name, role and password is the required parameter to create or update. first_name and last_name are optional parameters in PowerFlex version 4.5.
+  name     = "terraform"
+  role     = "SystemAdmin" # Monitor/SuperUser/SystemAdmin/StorageAdmin/LifecycleAdmin/ReplicationManager/SnapshotManager/SecurityAdmin/DriveReplacer/Technician/Support
+  password = "Password123@"
+}
+
+# Example for creating user. After successful execution, user will be created with LifecycleAdmin role. Below example works for PowerFlex version 4.6.
+resource "powerflex_user" "test" {
+  name       = "terraform"
+  role       = "LifecycleAdmin" # Monitor/SuperUser/SystemAdmin/StorageAdmin/LifecycleAdmin/ReplicationManager/SnapshotManager/SecurityAdmin/DriveReplacer/Technician/Support
+  password   = "Password123@"
+  first_name = "terraform"
+  last_name  = "terraform"
 }
 ```
 
@@ -73,8 +91,8 @@ After the execution of above resource block, new user would have been created on
 
 ### Optional
 
-- `first_name` (String) First name of the user. PowerFlex version 3.6 does not support the first_name attribute.
-- `last_name` (String) Last name of the user. PowerFlex version 3.6 does not support the last_name attribute.
+- `first_name` (String) First name of the user. PowerFlex version 3.6 does not support the first_name attribute. It is mandatory for PowerFlex version 4.6.
+- `last_name` (String) Last name of the user. PowerFlex version 3.6 does not support the last_name attribute. It is mandatory for PowerFlex version 4.6.
 
 ### Read-Only
 

--- a/examples/resources/powerflex_user/resource.tf
+++ b/examples/resources/powerflex_user/resource.tf
@@ -19,11 +19,29 @@ limitations under the License.
 # Create, Update, Delete is supported for this resource
 # Import is supported.
 
-# Example for creating user. After successful execution, user will be created with Monitor role.
+# Example for creating user. After successful execution, user will be created with Monitor role. Below example works for PowerFlex version 3.6.
 resource "powerflex_user" "newUser" {
 
   # name, role and password is the required parameter to create or update. Only role can be updated.
-  name     = "StorageAdmin"
+  name     = "terraform"
   role     = "Monitor" # Administrator/Monitor/Configure/Security/FrontendConfig/BackendConfig
   password = "Password"
+}
+
+# Example for creating user. After successful execution, user will be created with SystemAdmin role. Below example works for PowerFlex version 4.5.
+resource "powerflex_user" "newUser" {
+
+  # name, role and password is the required parameter to create or update. first_name and last_name are optional parameters in PowerFlex version 4.5.
+  name     = "terraform"
+  role     = "SystemAdmin" # Monitor/SuperUser/SystemAdmin/StorageAdmin/LifecycleAdmin/ReplicationManager/SnapshotManager/SecurityAdmin/DriveReplacer/Technician/Support
+  password = "Password123@"
+}
+
+# Example for creating user. After successful execution, user will be created with LifecycleAdmin role. Below example works for PowerFlex version 4.6.
+resource "powerflex_user" "test" {
+  name       = "terraform"
+  role       = "LifecycleAdmin" # Monitor/SuperUser/SystemAdmin/StorageAdmin/LifecycleAdmin/ReplicationManager/SnapshotManager/SecurityAdmin/DriveReplacer/Technician/Support
+  password   = "Password123@"
+  first_name = "terraform"
+  last_name  = "terraform"
 }

--- a/powerflex/provider/user_resource.go
+++ b/powerflex/provider/user_resource.go
@@ -121,19 +121,19 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				MarkdownDescription: "Password of the user. For PowerFlex version 3.6, cannot be updated.",
 			},
 			"first_name": schema.StringAttribute{
-				Description:         "First name of the user. PowerFlex version 3.6 does not support the first_name attribute.",
+				Description:         "First name of the user. PowerFlex version 3.6 does not support the first_name attribute. It is mandatory for PowerFlex version 4.6.",
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "First name of the user. PowerFlex version 3.6 does not support the first_name attribute.",
+				MarkdownDescription: "First name of the user. PowerFlex version 3.6 does not support the first_name attribute. It is mandatory for PowerFlex version 4.6.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"last_name": schema.StringAttribute{
-				Description:         "Last name of the user. PowerFlex version 3.6 does not support the last_name attribute.",
+				Description:         "Last name of the user. PowerFlex version 3.6 does not support the last_name attribute. It is mandatory for PowerFlex version 4.6.",
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "Last name of the user. PowerFlex version 3.6 does not support the last_name attribute.",
+				MarkdownDescription: "Last name of the user. PowerFlex version 3.6 does not support the last_name attribute. It is mandatory for PowerFlex version 4.6.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
# Description
PR is raised to add examples of user resource for different PowerFlex versions

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 80% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B