### PR TITLE
Stop IP and ESXi block from updating in sdc_host res

### DIFF
--- a/powerflex/helper/common.go
+++ b/powerflex/helper/common.go
@@ -1,0 +1,19 @@
+package helper
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+)
+
+func isKnown(v attr.Value) bool {
+	return !(v.IsUnknown() || v.IsNull())
+}
+
+// Known returns true if all values are known
+func Known(vs ...attr.Value) bool {
+	for _, v := range vs {
+		if !isKnown(v) {
+			return false
+		}
+	}
+	return true
+}

--- a/powerflex/helper/common.go
+++ b/powerflex/helper/common.go
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://mozilla.org/MPL/2.0/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helper
 
 import (

--- a/powerflex/helper/sdc_host_esxi.go
+++ b/powerflex/helper/sdc_host_esxi.go
@@ -139,9 +139,10 @@ func (r *SdcHostResource) CreateEsxi(ctx context.Context, plan models.SdcHostMod
 	tflog.Info(ctx, "Checking for installed scini module")
 	op, err = esxi.GetModuleByName("scini")
 	if err != nil {
+		tflog.Info(ctx, "Scini module not found: "+op)
 		respDiagnostics.AddError(
 			"Scini module not found after reboot 2",
-			err.Error()+"\n"+op,
+			err.Error()+"\nPlease verify that the input GUID and MDM IPs are correct.",
 		)
 		return respDiagnostics
 	}

--- a/powerflex/provider/sdc_host_resource.go
+++ b/powerflex/provider/sdc_host_resource.go
@@ -367,7 +367,7 @@ func (r *sdcHostResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		resp.Diagnostics.AddAttributeError(
 			path.Root("ip"),
 			"SDC IP cannot be updated through this resource",
-			"Please update the SDC IP by other means and run terraform refresh",
+			"Please update the SDC IP by other means and refresh state by running terraform apply -refresh-only",
 		)
 	}
 }

--- a/powerflex/provider/sdc_host_resource_test.go
+++ b/powerflex/provider/sdc_host_resource_test.go
@@ -230,6 +230,26 @@ func TestAccSDCHostResourceUbuntu(t *testing.T) {
 					SdcHostResourceTestData.UbuntuPkgPath, strings.Join(SdcHostResourceTestData.MdmIPs, `", "`)),
 				ExpectError: regexp.MustCompile(`.*mdm_ips cannot be changed.*`),
 			},
+			// Update ip negative
+			{
+				Config: ProviderConfigForTesting + fmt.Sprintf(`
+				resource powerflex_sdc_host sdc {
+					ip = "10.10.10.10"
+					remote = {
+						port = "%s"
+						user = "%s"
+						password = "%s"
+					}
+					os_family = "linux"
+					name = "sdc-ubuntu2"
+					package_path = "%s" 
+					mdm_ips = ["%s"]
+				}
+				`, SdcHostResourceTestData.UbuntuPort, SdcHostResourceTestData.UbuntuUser, SdcHostResourceTestData.UbuntuPassword,
+					SdcHostResourceTestData.UbuntuPkgPath, strings.Join(SdcHostResourceTestData.MdmIPs, `", "`)),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`.*SDC IP cannot be updated through this resource.*`),
+			},
 			// Update package negative
 			{
 				Config: ProviderConfigForTesting + fmt.Sprintf(`
@@ -521,6 +541,76 @@ func TestAccSDCHostResourceEsxi(t *testing.T) {
 				`, SdcHostResourceTestData.EsxiIP, SdcHostResourceTestData.EsxiPort, SdcHostResourceTestData.EsxiUser, SdcHostResourceTestData.EsxiPassword,
 					strings.Join(SdcHostResourceTestData.MdmIPs, `", "`)),
 				ExpectError: regexp.MustCompile(`.*package cannot be changed.*`),
+			},
+			// Update guid negative
+			{
+				Config: ProviderConfigForTesting + randomGUID + fmt.Sprintf(`
+				resource powerflex_sdc_host sdc {
+					ip = "%s"
+					remote = {
+						port = "%s"
+						user = "%s"
+						password = "%s"
+					}
+					esxi = {
+						guid = "invalid"
+					}
+					os_family = "esxi"
+					name = "sdc-esxi2"
+					package_path = "/dummy/tfaccsdc2.tar" 
+					mdm_ips = ["%s"]
+				}
+				`, SdcHostResourceTestData.EsxiIP, SdcHostResourceTestData.EsxiPort, SdcHostResourceTestData.EsxiUser, SdcHostResourceTestData.EsxiPassword,
+					strings.Join(SdcHostResourceTestData.MdmIPs, `", "`)),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`.*ESXi SDC details cannot be updated.*`),
+			},
+			// Update vib ignore negative
+			{
+				Config: ProviderConfigForTesting + randomGUID + fmt.Sprintf(`
+				resource powerflex_sdc_host sdc {
+					ip = "%s"
+					remote = {
+						port = "%s"
+						user = "%s"
+						password = "%s"
+					}
+					esxi = {
+						guid = random_uuid.sdc_guid.result
+						verify_vib_signature = false
+					}
+					os_family = "esxi"
+					name = "sdc-esxi2"
+					package_path = "/dummy/tfaccsdc2.tar" 
+					mdm_ips = ["%s"]
+				}
+				`, SdcHostResourceTestData.EsxiIP, SdcHostResourceTestData.EsxiPort, SdcHostResourceTestData.EsxiUser, SdcHostResourceTestData.EsxiPassword,
+					strings.Join(SdcHostResourceTestData.MdmIPs, `", "`)),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`.*ESXi SDC details cannot be updated.*`),
+			},
+			// Update IP negative
+			{
+				Config: ProviderConfigForTesting + randomGUID + fmt.Sprintf(`
+				resource powerflex_sdc_host sdc {
+					ip = "10.10.10.10"
+					remote = {
+						port = "%s"
+						user = "%s"
+						password = "%s"
+					}
+					esxi = {
+						guid = random_uuid.sdc_guid.result
+					}
+					os_family = "esxi"
+					name = "sdc-esxi2"
+					package_path = "/dummy/tfaccsdc2.tar" 
+					mdm_ips = ["%s"]
+				}
+				`, SdcHostResourceTestData.EsxiPort, SdcHostResourceTestData.EsxiUser, SdcHostResourceTestData.EsxiPassword,
+					strings.Join(SdcHostResourceTestData.MdmIPs, `", "`)),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`.*SDC IP cannot be updated through this resource.*`),
 			},
 			// Update os negative
 			{


### PR DESCRIPTION
Tested via mock server
```
root@lglap049:~/terraform-provider-powerflex# go test ./powerflex/provider/ -v -run TestAccSDCHostResource -timeout 3h
=== RUN   TestAccSDCHostResourceUbuntu
--- PASS: TestAccSDCHostResourceUbuntu (21.87s)
=== RUN   TestAccSDCHostResourceEsxiNeg
--- PASS: TestAccSDCHostResourceEsxiNeg (0.34s)
=== RUN   TestAccSDCHostResourceEsxi
--- PASS: TestAccSDCHostResourceEsxi (121.47s)
=== RUN   TestAccSDCHostResourceNegative
--- PASS: TestAccSDCHostResourceNegative (62.24s)
=== RUN   TestAccSDCHostResourcePositive
    sdc_host_resource_win_test.go:62: Skipping this test case for real environment
--- SKIP: TestAccSDCHostResourcePositive (0.00s)
=== RUN   TestAccSDCHostResourceRPMPositive
    sdc_host_resource_win_test.go:87: Skipping this test case for real environment
--- SKIP: TestAccSDCHostResourceRPMPositive (0.00s)
PASS
ok      terraform-provider-powerflex/powerflex/provider 205.934s
root@lglap049:~/terraform-provider-powerflex#
```