### PR TITLE
NVMe host name could be unassigned

### DIFF
--- a/docs/resources/replication_consistency_group.md
+++ b/docs/resources/replication_consistency_group.md
@@ -33,14 +33,14 @@ limitations under the License.
 terraform {
   required_providers {
     powerflex = {
-      source  = "registry.terraform.io/dell/powerflex"
-      configuration_aliases = [ powerflex.source, powerflex.destination ]
+      source                = "registry.terraform.io/dell/powerflex"
+      configuration_aliases = [powerflex.source, powerflex.destination]
     }
   }
 }
 
 provider "powerflex" {
-  alias = "source"
+  alias    = "source"
   username = var.username_source
   password = var.password_source
   endpoint = var.endpoint_source
@@ -49,7 +49,7 @@ provider "powerflex" {
 }
 
 provider "powerflex" {
-  alias = "destination"
+  alias    = "destination"
   username = var.username_destination
   password = var.password_destination
   endpoint = var.endpoint_destination
@@ -59,12 +59,12 @@ provider "powerflex" {
 
 data "powerflex_protection_domain" "source_protection_domain" {
   provider = powerflex.source
-  name = var.source_protection_domain_name
+  name     = var.source_protection_domain_name
 }
 
 data "powerflex_protection_domain" "destination_protection_domain" {
   provider = powerflex.destination
-  name =  var.destination_protection_domain_name
+  name     = var.destination_protection_domain_name
 }
 
 resource "powerflex_replication_consistency_group" "example" {

--- a/examples/resources/powerflex_replication_consistency_group/import.tf
+++ b/examples/resources/powerflex_replication_consistency_group/import.tf
@@ -17,7 +17,7 @@ limitations under the License.
 terraform {
   required_providers {
     powerflex = {
-      source  = "registry.terraform.io/dell/powerflex"
+      source = "registry.terraform.io/dell/powerflex"
     }
   }
 }
@@ -36,16 +36,16 @@ data "powerflex_replication_consistancy_group" "existing" {
 
 // Import all of the replication consistency groups
 import {
-    for_each = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details
-    to = powerflex_replication_consistency_group.this[each.key]
-    id = each.value.id
+  for_each = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details
+  to       = powerflex_replication_consistency_group.this[each.key]
+  id       = each.value.id
 }
 
 // Add them to the terraform state
 resource "powerflex_replication_consistency_group" "this" {
-    count = length(data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details)
-    name = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].name
-    protection_domain_id = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].protection_domain_id
-    remote_protection_domain_id = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].remote_protection_domain_id
-    destination_system_id = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].destination_system_id
+  count                       = length(data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details)
+  name                        = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].name
+  protection_domain_id        = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].protection_domain_id
+  remote_protection_domain_id = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].remote_protection_domain_id
+  destination_system_id       = data.powerflex_replication_consistancy_group.existing.replication_consistency_group_details[count.index].destination_system_id
 }

--- a/examples/resources/powerflex_replication_consistency_group/input.tfvars
+++ b/examples/resources/powerflex_replication_consistency_group/input.tfvars
@@ -16,15 +16,15 @@ limitations under the License.
 */
 
 # Source Vars
-username_source = "example_source_user"
-password_source = "example_source_password"
-endpoint_source = "example_source_endpoint"
-name = "example_replication_consistancy_group_name"
-rpo_in_seconds = 15
+username_source               = "example_source_user"
+password_source               = "example_source_password"
+endpoint_source               = "example_source_endpoint"
+name                          = "example_replication_consistancy_group_name"
+rpo_in_seconds                = 15
 source_protection_domain_name = "example_source_protection_domain"
 
 # Destination Vars
-username_destination = "example_destination_user"
-password_destination = "example_destination_password"
-endpoint_destination = "example_destination_endpoint"
+username_destination               = "example_destination_user"
+password_destination               = "example_destination_password"
+endpoint_destination               = "example_destination_endpoint"
 destination_protection_domain_name = "example_datasource_protection_domain"

--- a/examples/resources/powerflex_replication_consistency_group/resource.tf
+++ b/examples/resources/powerflex_replication_consistency_group/resource.tf
@@ -18,14 +18,14 @@ limitations under the License.
 terraform {
   required_providers {
     powerflex = {
-      source  = "registry.terraform.io/dell/powerflex"
-      configuration_aliases = [ powerflex.source, powerflex.destination ]
+      source                = "registry.terraform.io/dell/powerflex"
+      configuration_aliases = [powerflex.source, powerflex.destination]
     }
   }
 }
 
 provider "powerflex" {
-  alias = "source"
+  alias    = "source"
   username = var.username_source
   password = var.password_source
   endpoint = var.endpoint_source
@@ -34,7 +34,7 @@ provider "powerflex" {
 }
 
 provider "powerflex" {
-  alias = "destination"
+  alias    = "destination"
   username = var.username_destination
   password = var.password_destination
   endpoint = var.endpoint_destination
@@ -44,12 +44,12 @@ provider "powerflex" {
 
 data "powerflex_protection_domain" "source_protection_domain" {
   provider = powerflex.source
-  name = var.source_protection_domain_name
+  name     = var.source_protection_domain_name
 }
 
 data "powerflex_protection_domain" "destination_protection_domain" {
   provider = powerflex.destination
-  name =  var.destination_protection_domain_name
+  name     = var.destination_protection_domain_name
 }
 
 resource "powerflex_replication_consistency_group" "example" {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module terraform-provider-powerflex
 
-go 1.23.0
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/bramvdbogaerde/go-scp v1.5.0
-	github.com/bytedance/mockey v1.2.12
-	github.com/dell/goscaleio v1.16.1-0.20241022165321-a93b44d00f68
+	github.com/bytedance/mockey v1.2.13
+	github.com/dell/goscaleio v1.16.1-0.20241025023117-756f3e40e7aa
 	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/bramvdbogaerde/go-scp v1.5.0 h1:a9BinAjTfQh273eh7vd3qUgmBC+bx+3TRDtkZ
 github.com/bramvdbogaerde/go-scp v1.5.0/go.mod h1:on2aH5AxaFb2G0N5Vsdy6B0Ml7k9HuHSwfo1y0QzAbQ=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
-github.com/bytedance/mockey v1.2.12 h1:aeszOmGw8CPX8CRx1DZ/Glzb1yXvhjDh6jdFBNZjsU4=
-github.com/bytedance/mockey v1.2.12/go.mod h1:3ZA4MQasmqC87Tw0w7Ygdy7eHIc2xgpZ8Pona5rsYIk=
+github.com/bytedance/mockey v1.2.13 h1:jokWZAm/pUEbD939Rhznz615MKUCZNuvCFQlJ2+ntoo=
+github.com/bytedance/mockey v1.2.13/go.mod h1:1BPHF9sol5R1ud/+0VEHGQq/+i2lN+GTsr3O2Q9IENY=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -31,8 +31,10 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/goscaleio v1.16.1-0.20241022165321-a93b44d00f68 h1:873zgxtsMOJUoHecVqSwuEaIx4a0QGzldwLtiyLv0XE=
-github.com/dell/goscaleio v1.16.1-0.20241022165321-a93b44d00f68/go.mod h1:dB1a2wXevGps25VAda+6WDp+NTUdgMZXvQVM0YOBpX8=
+github.com/dell/goscaleio v1.16.1-0.20241024054329-c49dc1d4c471 h1:StR0KLt5ugSIjTrcyJYI7yZzr+TWUtxFAxjdaEazcdY=
+github.com/dell/goscaleio v1.16.1-0.20241024054329-c49dc1d4c471/go.mod h1:dB1a2wXevGps25VAda+6WDp+NTUdgMZXvQVM0YOBpX8=
+github.com/dell/goscaleio v1.16.1-0.20241025023117-756f3e40e7aa h1:3tKyqPUoj93VcSiL2lN2NmhuTrnF5AzfL92eUZH0s7c=
+github.com/dell/goscaleio v1.16.1-0.20241025023117-756f3e40e7aa/go.mod h1:dB1a2wXevGps25VAda+6WDp+NTUdgMZXvQVM0YOBpX8=
 github.com/dylanmei/iso8601 v0.1.0 h1:812NGQDBcqquTfH5Yeo7lwR0nzx/cKdsmf3qMjPURUI=
 github.com/dylanmei/iso8601 v0.1.0/go.mod h1:w9KhXSgIyROl1DefbMYIE7UVSIvELTbMrCfx+QkYnoQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/powerflex/helper/nvme_host_helper.go
+++ b/powerflex/helper/nvme_host_helper.go
@@ -18,8 +18,10 @@ limitations under the License.
 package helper
 
 import (
+	"fmt"
 	"terraform-provider-powerflex/powerflex/models"
 
+	"github.com/dell/goscaleio"
 	goscaleio_types "github.com/dell/goscaleio/types/v1"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -41,4 +43,36 @@ func GetNvmeHostState(host goscaleio_types.NvmeHost) models.NvmeHostDatasourceMo
 		})
 	}
 	return model
+}
+
+// setNvmeHostName sets the name of the NVMe host.
+// If the name is empty, it will be set to the host type + ID
+func setNvmeHostName(host *goscaleio_types.NvmeHost) {
+	if len(host.Name) == 0 {
+		host.Name = fmt.Sprintf("%s:%s", host.HostType, host.ID)
+	}
+}
+
+// GetNvmeHostByID returns an NVMe host by id
+func GetNvmeHostByID(system *goscaleio.System, id string) (*goscaleio_types.NvmeHost, error) {
+	host, err := system.GetNvmeHostByID(id)
+	if err != nil {
+		return host, err
+	}
+	setNvmeHostName(host)
+	return host, nil
+}
+
+// GetAllNvmeHosts returns all NvmeHost list
+func GetAllNvmeHosts(system *goscaleio.System) ([]goscaleio_types.NvmeHost, error) {
+	hosts, err := system.GetAllNvmeHosts()
+	if err != nil {
+		return hosts, err
+	}
+
+	for i := range hosts {
+		setNvmeHostName(&hosts[i])
+	}
+
+	return hosts, nil
 }

--- a/powerflex/provider/nvme_host_datasource.go
+++ b/powerflex/provider/nvme_host_datasource.go
@@ -92,7 +92,7 @@ func (d *nvmeHostDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	nvmeHosts, err := system.GetAllNvmeHosts()
+	nvmeHosts, err := helper.GetAllNvmeHosts(system)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Powerflex NVMe Hosts",

--- a/powerflex/provider/nvme_host_resource.go
+++ b/powerflex/provider/nvme_host_resource.go
@@ -26,11 +26,9 @@ import (
 	scaleiotypes "github.com/dell/goscaleio/types/v1"
 
 	"github.com/dell/goscaleio"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -67,9 +65,6 @@ func (r *NvmeHostResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				MarkdownDescription: "Name of the NVMe host",
 				Optional:            true,
 				Computed:            true,
-				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-				},
 			},
 			"system_id": schema.StringAttribute{
 				Description:         "The ID of the system.",
@@ -152,7 +147,7 @@ func (r *NvmeHostResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	host, err := r.system.GetNvmeHostByID(hostResp.ID)
+	host, err := helper.GetNvmeHostByID(r.system, hostResp.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Could not read NVMe host with ID %s", hostResp.ID),
@@ -161,7 +156,7 @@ func (r *NvmeHostResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	err = helper.CopyFields(ctx, host.NvmeHost, &plan)
+	err = helper.CopyFields(ctx, host, &plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating NVMe host",
@@ -189,7 +184,7 @@ func (r *NvmeHostResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	host, err := r.system.GetNvmeHostByID(state.ID.ValueString())
+	host, err := helper.GetNvmeHostByID(r.system, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Could not get the VNMe host Details",
@@ -198,7 +193,7 @@ func (r *NvmeHostResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	err = helper.CopyFieldsToNonNestedModel(ctx, host.NvmeHost, &state)
+	err = helper.CopyFieldsToNonNestedModel(ctx, host, &state)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading NVMe host",
@@ -279,7 +274,7 @@ func (r *NvmeHostResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	err = helper.CopyFieldsToNonNestedModel(ctx, host.NvmeHost, &state)
+	err = helper.CopyFieldsToNonNestedModel(ctx, host, &state)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading NVMe host",

--- a/powerflex/provider/nvme_host_resource_test.go
+++ b/powerflex/provider/nvme_host_resource_test.go
@@ -207,10 +207,10 @@ func TestAccNvmeHostResourceHelperNegative(t *testing.T) {
 						FunctionMocker.UnPatch()
 					}
 					createFuncMocker = Mock((*goscaleio.System).CreateNvmeHost).Return(&scaleiotypes.NvmeHostResp{ID: "1"}, nil).Build()
-					getFuncMocker = Mock((*goscaleio.System).GetNvmeHostByID).Return(goscaleio.NewNvmeHost(nil, &scaleiotypes.NvmeHost{
+					getFuncMocker = Mock((*goscaleio.System).GetNvmeHostByID).Return(&scaleiotypes.NvmeHost{
 						ID:   "1",
 						Name: "host",
-					}), nil).Build()
+					}, nil).Build()
 					FunctionMocker = Mock(helper.CopyFields).Return(fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfigForTesting + nvmeHostResourceConfig,


### PR DESCRIPTION


<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
When creating an NVMe host without specifying a name, the PowerFlex manager uses HostType:ID as the display name, and we follow the same behavior.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] AT
- [x] UT
![image](https://github.com/user-attachments/assets/8839d077-57fb-44f9-b340-f34b6fe7aff4)
![image](https://github.com/user-attachments/assets/de893b01-6791-46ae-ab24-7cf1c28bdf37)
![image](https://github.com/user-attachments/assets/82b6b00d-9f7f-465d-89f8-d1b4082b1308)
