### PR TITLE
Added Regex Filter to datasource filtering

### DIFF
--- a/docs/data-sources/compliance_report_resource_group.md
+++ b/docs/data-sources/compliance_report_resource_group.md
@@ -51,6 +51,18 @@ limitations under the License.
 data "powerflex_compliance_report_resource_group" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_compliance_report_resource_group" "compliance_report_resource_group_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     model = ["^Powerflex.*$"]
+#   }
+# }
+
+# output "complianceReportResourceGroupFilterRegexResult"{
+#  value = data.powerflex_compliance_report_resource_group.compliance_report_resource_group_filter_regex.compliance_reports
+# }
+
 # this datasource supports multiple filters like ip_address, host_name, service_tag, compliant,etc.
 # Note: If both filters are used simultaneously, the results will include any records that match either of the filters.
 # data "powerflex_compliance_report_resource_group" "complianceReport" {
@@ -72,7 +84,7 @@ data "powerflex_compliance_report_resource_group" "example1" {
 # }
 
 output "result" {
-  value = data.powerflex_compliance_report_resource_group.example1
+  value = data.powerflex_compliance_report_resource_group.example1.compliance_reports
 }
 ```
 

--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -56,6 +56,18 @@ output "deviceResult" {
   value = data.powerflex_device.all.device_model
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_device" "device_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     temperature_state = ["^.*Failed$"]
+#   }
+# }
+
+# output "faultSetFilterRegexResult"{
+#  value = data.powerflex_device.device_filter_regex.device_model
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/docs/data-sources/fault_set.md
+++ b/docs/data-sources/fault_set.md
@@ -56,6 +56,18 @@ output "fault_set_result_all" {
   value = data.powerflex_fault_set.all.fault_set_details
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_fault_set" "fault_set_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     id = ["^.*0f$"]
+#   }
+# }
+
+# output "faultSetFilterRegexResult"{
+#  value = data.powerflex_fault_set.fault_set_filter_regex.fault_set_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/

--- a/docs/data-sources/firmware_repository.md
+++ b/docs/data-sources/firmware_repository.md
@@ -55,6 +55,18 @@ output "powerflex_firmware_repository_all_result" {
   value = data.powerflex_firmware_repository.all.firmware_repository_details
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_firmware_repository" "firmware_repository_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     disk_location = ["^https://powerflex.*$"]
+#   }
+# }
+
+# output "firmwareRepositoryFilterRegexResult"{
+#  value = data.powerflex_firmware_repository.firmware_repository_filter_regex.firmware_repository_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/docs/data-sources/node.md
+++ b/docs/data-sources/node.md
@@ -52,6 +52,18 @@ limitations under the License.
 data "powerflex_node" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_node" "node_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     manufacturer = ["^.*Corp.*$"]
+#   }
+# }
+
+# output "nodeFilterRegexResult"{
+#  value = data.powerflex_node.node_filter_regex.node_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/docs/data-sources/nvme_host.md
+++ b/docs/data-sources/nvme_host.md
@@ -55,6 +55,19 @@ limitations under the License.
 data "powerflex_nvme_host" "example1" {
 }
 
+
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_nvme_host" "nvme_host_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     system_id = ["^.*0f$"]
+#   }
+# }
+
+# output "nvmeHostFilterRegexResult"{
+#  value = data.powerflex_nvme_host.nvme_host_filter_regex.nvme_host_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 
@@ -72,7 +85,7 @@ data "powerflex_nvme_host" "example2" {
 }
 
 output "nvme_host_result" {
-  value = data.powerflex_nvme_host.example1
+  value = data.powerflex_nvme_host.example1.nvme_host_details
 }
 ```
 

--- a/docs/data-sources/nvme_target.md
+++ b/docs/data-sources/nvme_target.md
@@ -55,6 +55,18 @@ limitations under the License.
 data "powerflex_nvme_target" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_nvme_target" "nvme_target_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     software_version_info = ["^R4_5.*$"]
+#   }
+# }
+
+# output "nvmeTargetFilterRegexResult"{
+#  value = data.powerflex_nvme_target.nvme_target_filter_regex.nvme_target_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 
@@ -81,7 +93,7 @@ data "powerflex_nvme_target" "example" {
 }
 
 output "nvme_target_result" {
-  value = data.powerflex_nvme_target.example
+  value = data.powerflex_nvme_target.example.nvme_target_details
 }
 ```
 

--- a/docs/data-sources/os_repository.md
+++ b/docs/data-sources/os_repository.md
@@ -52,6 +52,18 @@ limitations under the License.
 data "powerflex_os_repository" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_os_repository" "os_repository_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     source_path = ["^c://.*$"]
+#   }
+# }
+
+# output "osRepositoryFilterRegexResult"{
+#  value = data.powerflex_os_repository.os_repository_filter_regex.os_repositories
+# }
+
 # # Get OS Repository details by ID
 # data "powerflex_os_repository" "example2" {
 #   # this datasource supports filters like os repsoitory id, name, source path, etc.
@@ -84,7 +96,7 @@ data "powerflex_os_repository" "example1" {
 # }
 
 output "os_repository_result" {
-  value = data.powerflex_os_repository.example1
+  value = data.powerflex_os_repository.example1.os_repositories
 }
 ```
 

--- a/docs/data-sources/peer_system.md
+++ b/docs/data-sources/peer_system.md
@@ -53,6 +53,18 @@ limitations under the License.
 data "powerflex_peer_system" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_peer_system" "peer_system_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     perf_profile = ["^.*Performance$"]
+#   }
+# }
+
+# output "peerSystemFilterRegexResult"{
+#  value = data.powerflex_peer_system.peer_system_filter_regex.peer_system_details
+# }
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples
@@ -72,7 +84,7 @@ data "powerflex_peer_system" "example1" {
 # }
 
 output "peer_system_result" {
-  value = data.powerflex_peer_system.example1
+  value = data.powerflex_peer_system.example1.peer_system_details
 }
 ```
 

--- a/docs/data-sources/protection_domain.md
+++ b/docs/data-sources/protection_domain.md
@@ -55,6 +55,19 @@ output "inputAll" {
   value = data.powerflex_protection_domain.all.protection_domains
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_protection_domain" "protection_domain_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     rf_cache_opertional_mode = ["^.*Write.*$"]
+#   }
+# }
+
+# output "protectionDomainFilterRegexResult"{
+#  value = data.powerflex_protection_domain.protection_domain_filter_regex.protection_domains
+# }
+
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples

--- a/docs/data-sources/replication_consistency_group.md
+++ b/docs/data-sources/replication_consistency_group.md
@@ -36,6 +36,19 @@ output "rcgResult" {
   value = data.powerflex_replication_consistency_group.rcg
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_replication_consistency_group" "rcg_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     target_volume_access_mode = ["^.*Access$"]
+#   }
+# }
+
+# output "rcgFilterRegexResult"{
+#  value = data.powerflex_replication_consistency_group.rcg_filter_regex.rcg_filter
+# }
+
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/docs/data-sources/replication_pair.md
+++ b/docs/data-sources/replication_pair.md
@@ -40,6 +40,18 @@ output "rpResult" {
   value = data.powerflex_replication_pair.rp
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_replication_pair" "replication_pair_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     peer_system_name = ["^Peer_System_.*$"]
+#   }
+# }
+
+# output "replicationPairFilterRegexResult"{
+#  value = data.powerflex_replication_pair.replication_pair_filter_regex.rp_filter
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/docs/data-sources/resource_group.md
+++ b/docs/data-sources/resource_group.md
@@ -52,6 +52,19 @@ limitations under the License.
 data "powerflex_resource_group" "example1" {
 }
 
+
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_resource_group" "resource_group_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     deployment_finished_date = ["^2024-01-10.*$"]
+#   }
+# }
+
+# output "resourceGroupFilterRegexResult"{
+#  value = data.powerflex_resource_group.resource_group_filter_regex.resource_group_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/

--- a/docs/data-sources/sdc.md
+++ b/docs/data-sources/sdc.md
@@ -57,6 +57,18 @@ output "allsdcresult" {
   value = data.powerflex_sdc.all
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_sdc" "sdc_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     system_id = ["^.*0f$"]
+#   }
+# }
+
+# output "sdcFilterRegexResult"{
+#  value = data.powerflex_sdc.sdc_filter_regex.sdcs
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/
@@ -75,7 +87,7 @@ data "powerflex_sdc" "filtered" {
 
 # Returns filtered sdcs matching criteria
 output "filteredsdcresult" {
-  value = data.powerflex_sdc.filtered
+  value = data.powerflex_sdc.filtered.sdcs
 }
 # -----------------------------------------------------------------------------------
 ```

--- a/docs/data-sources/sds.md
+++ b/docs/data-sources/sds.md
@@ -55,6 +55,18 @@ limitations under the License.
 data "powerflex_sds" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_sds" "sds_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     maintenance_type = ["^.*Maintenance$"]
+#   }
+# }
+
+# output "sdsFilterRegexResult"{
+#  value = data.powerflex_sds.sds_filter_regex.sds_details
+# }
+
 # Get Sds details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples
@@ -96,7 +108,7 @@ data "powerflex_sds" "example1" {
 # }
 
 output "allsdcresult" {
-  value = data.powerflex_sds.example1
+  value = data.powerflex_sds.example1.sds_details
 }
 ```
 

--- a/docs/data-sources/snapshot_policy.md
+++ b/docs/data-sources/snapshot_policy.md
@@ -53,6 +53,18 @@ limitations under the License.
 data "powerflex_snapshot_policy" "sp" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_snapshot_policy" "snapshot_policy_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     system_id = ["^.*0f$"]
+#   }
+# }
+
+# output "snapshotPolicyFilterRegexResult"{
+#  value = data.powerflex_snapshot_policy.snapshot_policy_regex.sp
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/

--- a/docs/data-sources/storage_pool.md
+++ b/docs/data-sources/storage_pool.md
@@ -55,6 +55,19 @@ output "storagePoolallresult" {
   value = data.powerflex_storage_pool.all.storage_pools
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_storage_pool" "storage_pool_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     rebuild_io_priority_policy = ["^limit.*$"]
+#   }
+# }
+
+# output "storagePoolFilterRegexResult"{
+#  value = data.powerflex_storage_pool.storage_pool_regex.storage_pools
+# }
+
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples

--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -52,6 +52,18 @@ limitations under the License.
 data "powerflex_template" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_template" "template_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     created_date = ["^2024-01-05.*$"]
+#   }
+# }
+
+# output "templateFilterRegexResult"{
+#  value = data.powerflex_template.template_filter_regex.template_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -48,12 +48,24 @@ limitations under the License.
 
 // Empty filter block will return all the volumes
 data "powerflex_volume" "volume" {
-
 }
 
 output "volumeResult" {
   value = data.powerflex_volume.volume.volumes
 }
+
+
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_volume" "volume_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     volume_type = ["^.*Provisioned$"]
+#   }
+# }
+
+# output "volumeFilterRegexResult"{
+#  value = data.powerflex_volume.volume_filter_regex.volumes
+# }
 
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
@@ -85,7 +97,6 @@ data "powerflex_volume" "volume_filter" {
   #   replication_time_stamp                 = [1,2]
   }
 }
-
 
 output "volumeFilterResult" {
   value = data.powerflex_volume.volume_filter.volumes

--- a/docs/data-sources/vtree.md
+++ b/docs/data-sources/vtree.md
@@ -56,6 +56,19 @@ output "powerflex_vtree_all_result" {
   value = data.powerflex_vtree.all.vtree_details
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_vtree" "vtree_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     data_layout = ["^.*Granularity$"]
+#   }
+# }
+
+# output "vtreeFilterRegexResult"{
+#  value = data.powerflex_vtree.vtree_filter_regex.vtree_details
+# }
+
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples

--- a/docs/guides/datasource_filtering.md
+++ b/docs/guides/datasource_filtering.md
@@ -123,3 +123,28 @@ data "powerflex_example_datasource" "exampleFilter" {
 ```
 []
 ```
+
+## 5. If the filter value is using regular expressions:
+**Config:**
+```
+data "powerflex_example_datasource" "exampleFilter" {
+  filter {
+   id = ["^id-[1-2]$"]
+  }
+}
+```
+**Output:**
+```
+[
+   {
+   id = "id-1"
+   field = false
+   count = 1
+  },
+  {
+   id = "id-2"
+   field = true
+   count = 2
+  }
+]
+```

--- a/examples/data-sources/powerflex_compliance_report_resource_group/data-source.tf
+++ b/examples/data-sources/powerflex_compliance_report_resource_group/data-source.tf
@@ -20,6 +20,18 @@ limitations under the License.
 data "powerflex_compliance_report_resource_group" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_compliance_report_resource_group" "compliance_report_resource_group_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     model = ["^Powerflex.*$"]
+#   }
+# }
+
+# output "complianceReportResourceGroupFilterRegexResult"{
+#  value = data.powerflex_compliance_report_resource_group.compliance_report_resource_group_filter_regex.compliance_reports
+# }
+
 # this datasource supports multiple filters like ip_address, host_name, service_tag, compliant,etc.
 # Note: If both filters are used simultaneously, the results will include any records that match either of the filters.
 # data "powerflex_compliance_report_resource_group" "complianceReport" {
@@ -41,5 +53,5 @@ data "powerflex_compliance_report_resource_group" "example1" {
 # }
 
 output "result" {
-  value = data.powerflex_compliance_report_resource_group.example1
+  value = data.powerflex_compliance_report_resource_group.example1.compliance_reports
 }

--- a/examples/data-sources/powerflex_device/data-source.tf
+++ b/examples/data-sources/powerflex_device/data-source.tf
@@ -25,6 +25,18 @@ output "deviceResult" {
   value = data.powerflex_device.all.device_model
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_device" "device_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     temperature_state = ["^.*Failed$"]
+#   }
+# }
+
+# output "faultSetFilterRegexResult"{
+#  value = data.powerflex_device.device_filter_regex.device_model
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/examples/data-sources/powerflex_fault_set/data-source.tf
+++ b/examples/data-sources/powerflex_fault_set/data-source.tf
@@ -25,6 +25,18 @@ output "fault_set_result_all" {
   value = data.powerflex_fault_set.all.fault_set_details
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_fault_set" "fault_set_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     id = ["^.*0f$"]
+#   }
+# }
+
+# output "faultSetFilterRegexResult"{
+#  value = data.powerflex_fault_set.fault_set_filter_regex.fault_set_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/

--- a/examples/data-sources/powerflex_firmware_repository/data-source.tf
+++ b/examples/data-sources/powerflex_firmware_repository/data-source.tf
@@ -24,6 +24,18 @@ output "powerflex_firmware_repository_all_result" {
   value = data.powerflex_firmware_repository.all.firmware_repository_details
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_firmware_repository" "firmware_repository_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     disk_location = ["^https://powerflex.*$"]
+#   }
+# }
+
+# output "firmwareRepositoryFilterRegexResult"{
+#  value = data.powerflex_firmware_repository.firmware_repository_filter_regex.firmware_repository_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/examples/data-sources/powerflex_node/data-source.tf
+++ b/examples/data-sources/powerflex_node/data-source.tf
@@ -21,6 +21,18 @@ limitations under the License.
 data "powerflex_node" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_node" "node_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     manufacturer = ["^.*Corp.*$"]
+#   }
+# }
+
+# output "nodeFilterRegexResult"{
+#  value = data.powerflex_node.node_filter_regex.node_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/examples/data-sources/powerflex_nvme_host/data-source.tf
+++ b/examples/data-sources/powerflex_nvme_host/data-source.tf
@@ -21,6 +21,19 @@ limitations under the License.
 data "powerflex_nvme_host" "example1" {
 }
 
+
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_nvme_host" "nvme_host_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     system_id = ["^.*0f$"]
+#   }
+# }
+
+# output "nvmeHostFilterRegexResult"{
+#  value = data.powerflex_nvme_host.nvme_host_filter_regex.nvme_host_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 
@@ -38,5 +51,5 @@ data "powerflex_nvme_host" "example2" {
 }
 
 output "nvme_host_result" {
-  value = data.powerflex_nvme_host.example1
+  value = data.powerflex_nvme_host.example1.nvme_host_details
 }

--- a/examples/data-sources/powerflex_nvme_target/data-source.tf
+++ b/examples/data-sources/powerflex_nvme_target/data-source.tf
@@ -21,6 +21,18 @@ limitations under the License.
 data "powerflex_nvme_target" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_nvme_target" "nvme_target_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     software_version_info = ["^R4_5.*$"]
+#   }
+# }
+
+# output "nvmeTargetFilterRegexResult"{
+#  value = data.powerflex_nvme_target.nvme_target_filter_regex.nvme_target_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 
@@ -47,5 +59,5 @@ data "powerflex_nvme_target" "example" {
 }
 
 output "nvme_target_result" {
-  value = data.powerflex_nvme_target.example
+  value = data.powerflex_nvme_target.example.nvme_target_details
 }

--- a/examples/data-sources/powerflex_os_repository/data-source.tf
+++ b/examples/data-sources/powerflex_os_repository/data-source.tf
@@ -21,6 +21,18 @@ limitations under the License.
 data "powerflex_os_repository" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_os_repository" "os_repository_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     source_path = ["^c://.*$"]
+#   }
+# }
+
+# output "osRepositoryFilterRegexResult"{
+#  value = data.powerflex_os_repository.os_repository_filter_regex.os_repositories
+# }
+
 # # Get OS Repository details by ID
 # data "powerflex_os_repository" "example2" {
 #   # this datasource supports filters like os repsoitory id, name, source path, etc.
@@ -53,5 +65,5 @@ data "powerflex_os_repository" "example1" {
 # }
 
 output "os_repository_result" {
-  value = data.powerflex_os_repository.example1
+  value = data.powerflex_os_repository.example1.os_repositories
 }

--- a/examples/data-sources/powerflex_peer_system/data-source.tf
+++ b/examples/data-sources/powerflex_peer_system/data-source.tf
@@ -22,6 +22,18 @@ limitations under the License.
 data "powerflex_peer_system" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_peer_system" "peer_system_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     perf_profile = ["^.*Performance$"]
+#   }
+# }
+
+# output "peerSystemFilterRegexResult"{
+#  value = data.powerflex_peer_system.peer_system_filter_regex.peer_system_details
+# }
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples
@@ -41,5 +53,5 @@ data "powerflex_peer_system" "example1" {
 # }
 
 output "peer_system_result" {
-  value = data.powerflex_peer_system.example1
+  value = data.powerflex_peer_system.example1.peer_system_details
 }

--- a/examples/data-sources/powerflex_protection_domain/data-source.tf
+++ b/examples/data-sources/powerflex_protection_domain/data-source.tf
@@ -22,6 +22,19 @@ output "inputAll" {
   value = data.powerflex_protection_domain.all.protection_domains
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_protection_domain" "protection_domain_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     rf_cache_opertional_mode = ["^.*Write.*$"]
+#   }
+# }
+
+# output "protectionDomainFilterRegexResult"{
+#  value = data.powerflex_protection_domain.protection_domain_filter_regex.protection_domains
+# }
+
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples

--- a/examples/data-sources/powerflex_replication_consistency_group/data-source.tf
+++ b/examples/data-sources/powerflex_replication_consistency_group/data-source.tf
@@ -20,6 +20,19 @@ output "rcgResult" {
   value = data.powerflex_replication_consistency_group.rcg
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_replication_consistency_group" "rcg_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     target_volume_access_mode = ["^.*Access$"]
+#   }
+# }
+
+# output "rcgFilterRegexResult"{
+#  value = data.powerflex_replication_consistency_group.rcg_filter_regex.rcg_filter
+# }
+
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/examples/data-sources/powerflex_replication_pair/data-source.tf
+++ b/examples/data-sources/powerflex_replication_pair/data-source.tf
@@ -24,6 +24,18 @@ output "rpResult" {
   value = data.powerflex_replication_pair.rp
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_replication_pair" "replication_pair_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     peer_system_name = ["^Peer_System_.*$"]
+#   }
+# }
+
+# output "replicationPairFilterRegexResult"{
+#  value = data.powerflex_replication_pair.replication_pair_filter_regex.rp_filter
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/examples/data-sources/powerflex_resource_group/data-source.tf
+++ b/examples/data-sources/powerflex_resource_group/data-source.tf
@@ -21,6 +21,19 @@ limitations under the License.
 data "powerflex_resource_group" "example1" {
 }
 
+
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_resource_group" "resource_group_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     deployment_finished_date = ["^2024-01-10.*$"]
+#   }
+# }
+
+# output "resourceGroupFilterRegexResult"{
+#  value = data.powerflex_resource_group.resource_group_filter_regex.resource_group_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/

--- a/examples/data-sources/powerflex_sdc/data-source.tf
+++ b/examples/data-sources/powerflex_sdc/data-source.tf
@@ -26,6 +26,18 @@ output "allsdcresult" {
   value = data.powerflex_sdc.all
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_sdc" "sdc_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     system_id = ["^.*0f$"]
+#   }
+# }
+
+# output "sdcFilterRegexResult"{
+#  value = data.powerflex_sdc.sdc_filter_regex.sdcs
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/
@@ -44,7 +56,7 @@ data "powerflex_sdc" "filtered" {
 
 # Returns filtered sdcs matching criteria
 output "filteredsdcresult" {
-  value = data.powerflex_sdc.filtered
+  value = data.powerflex_sdc.filtered.sdcs
 }
 # -----------------------------------------------------------------------------------
 

--- a/examples/data-sources/powerflex_sds/data-source.tf
+++ b/examples/data-sources/powerflex_sds/data-source.tf
@@ -20,6 +20,18 @@ limitations under the License.
 data "powerflex_sds" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_sds" "sds_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     maintenance_type = ["^.*Maintenance$"]
+#   }
+# }
+
+# output "sdsFilterRegexResult"{
+#  value = data.powerflex_sds.sds_filter_regex.sds_details
+# }
+
 # Get Sds details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples
@@ -61,6 +73,6 @@ data "powerflex_sds" "example1" {
 # }
 
 output "allsdcresult" {
-  value = data.powerflex_sds.example1
+  value = data.powerflex_sds.example1.sds_details
 }
 

--- a/examples/data-sources/powerflex_snapshot_policy/data-source.tf
+++ b/examples/data-sources/powerflex_snapshot_policy/data-source.tf
@@ -20,6 +20,18 @@ limitations under the License.
 data "powerflex_snapshot_policy" "sp" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_snapshot_policy" "snapshot_policy_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     system_id = ["^.*0f$"]
+#   }
+# }
+
+# output "snapshotPolicyFilterRegexResult"{
+#  value = data.powerflex_snapshot_policy.snapshot_policy_regex.sp
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/

--- a/examples/data-sources/powerflex_storage_pool/data-source.tf
+++ b/examples/data-sources/powerflex_storage_pool/data-source.tf
@@ -26,6 +26,19 @@ output "storagePoolallresult" {
   value = data.powerflex_storage_pool.all.storage_pools
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_storage_pool" "storage_pool_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     rebuild_io_priority_policy = ["^limit.*$"]
+#   }
+# }
+
+# output "storagePoolFilterRegexResult"{
+#  value = data.powerflex_storage_pool.storage_pool_regex.storage_pools
+# }
+
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples

--- a/examples/data-sources/powerflex_template/data-source.tf
+++ b/examples/data-sources/powerflex_template/data-source.tf
@@ -21,6 +21,18 @@ limitations under the License.
 data "powerflex_template" "example1" {
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_template" "template_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     created_date = ["^2024-01-05.*$"]
+#   }
+# }
+
+# output "templateFilterRegexResult"{
+#  value = data.powerflex_template.template_filter_regex.template_details
+# }
+
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
 // For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples/ 

--- a/examples/data-sources/powerflex_volume/data-source.tf
+++ b/examples/data-sources/powerflex_volume/data-source.tf
@@ -17,12 +17,24 @@ limitations under the License.
 
 // Empty filter block will return all the volumes
 data "powerflex_volume" "volume" {
-
 }
 
 output "volumeResult" {
   value = data.powerflex_volume.volume.volumes
 }
+
+
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_volume" "volume_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     volume_type = ["^.*Provisioned$"]
+#   }
+# }
+
+# output "volumeFilterRegexResult"{
+#  value = data.powerflex_volume.volume_filter_regex.volumes
+# }
 
 // If multiple filter fields are provided then it will show the intersection of all of those fields.
 // If there is no intersection between the filters then an empty datasource will be returned
@@ -55,7 +67,7 @@ data "powerflex_volume" "volume_filter" {
   }
 }
 
-
 output "volumeFilterResult" {
   value = data.powerflex_volume.volume_filter.volumes
 }
+

--- a/examples/data-sources/powerflex_vtree/data-source.tf
+++ b/examples/data-sources/powerflex_vtree/data-source.tf
@@ -25,6 +25,19 @@ output "powerflex_vtree_all_result" {
   value = data.powerflex_vtree.all.vtree_details
 }
 
+# if a filter is of type string it has the ability to allow regular expressions
+# data "powerflex_vtree" "vtree_filter_regex" {
+#   filter{
+#     name = ["^System_.*$"]
+#     data_layout = ["^.*Granularity$"]
+#   }
+# }
+
+# output "vtreeFilterRegexResult"{
+#  value = data.powerflex_vtree.vtree_filter_regex.vtree_details
+# }
+
+
 # Get Peer System details using filter with all values
 # If there is no intersection between the filters then an empty datasource will be returned
 # For more information about how we do our datasource filtering check out our guides: https://dell.github.io/terraform-docs/docs/storage/platforms/powerflex/product_guide/examples

--- a/powerflex/helper/helper.go
+++ b/powerflex/helper/helper.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -388,7 +389,10 @@ func FilterByField(dataSources reflect.Value, fieldValue reflect.Value, field st
 					break
 				}
 
-				if fieldValueInDataSource.Interface() == interFieldValue.Interface() {
+				//check field value with regex here
+				pattern := regexp.MustCompile(fmt.Sprintf("%v", interFieldValue.Interface()))
+
+				if pattern.MatchString(fmt.Sprintf("%v", fieldValueInDataSource.Interface())) {
 					filteredData = reflect.Append(filteredData, reflect.ValueOf(dataSource))
 				}
 			}
@@ -397,8 +401,14 @@ func FilterByField(dataSources reflect.Value, fieldValue reflect.Value, field st
 			if err != nil {
 				return reflect.Zero(nil), err
 			}
+			// if field is not found in the data source then break and continue
+			if !fieldValueInDataSource.IsValid() || !interFieldValue.IsValid() {
+				break
+			}
 
-			if fieldValueInDataSource.Interface() == interFieldValue.Interface() {
+			pattern := regexp.MustCompile(fmt.Sprintf("%v", interFieldValue.Interface()))
+
+			if pattern.MatchString(fmt.Sprintf("%v", fieldValueInDataSource.Interface())) {
 				filteredData = reflect.Append(filteredData, reflect.ValueOf(dataSource))
 			}
 		}

--- a/powerflex/provider/firmware_repository_datasource_test.go
+++ b/powerflex/provider/firmware_repository_datasource_test.go
@@ -48,6 +48,13 @@ data "powerflex_firmware_repository" "filter-multiple" {
 	}
 }
 `
+var FRDataSourceRegex = `
+data "powerflex_firmware_repository" "filter-regex" {
+	filter {
+		name = ["^Intelligent.*$"]
+	}
+}
+`
 
 // AT
 func TestAccDatasourceAcceptanceFR(t *testing.T) {
@@ -91,6 +98,13 @@ func TestAccDatasourceFR(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.powerflex_firmware_repository.filter-multiple", "firmware_repository_details.0.minimal", "false"),
 					resource.TestCheckResourceAttr("data.powerflex_firmware_repository.filter-multiple", "firmware_repository_details.0.name", "Intelligent Catalog 45.373.00"),
+				),
+			},
+			// Filter Regex
+			{
+				Config: ProviderConfigForTesting + FRDataSourceRegex,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.powerflex_firmware_repository.filter-regex", "firmware_repository_details.0.name", "Intelligent Catalog 45.373.00"),
 				),
 			},
 			// Read error

--- a/powerflex/provider/os_repository_datasource_test.go
+++ b/powerflex/provider/os_repository_datasource_test.go
@@ -54,6 +54,14 @@ data "powerflex_os_repository" "test" {
 	}
   }
 `
+var OSRepoDataSourceConfig4 = `
+data "powerflex_os_repository" "test" {
+	# this datasource supports filters like os repsoitory ids, names, source path, etc.
+	filter {
+		id = ["^tfacc_.*$"]
+	}
+  }
+`
 
 func TestAccDatasourceOSRepo(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -81,6 +89,12 @@ func TestAccDatasourceOSRepo(t *testing.T) {
 					resource.TestCheckResourceAttr("data.powerflex_os_repository.test", "os_repositories.0.repo_type", OSRepoType),
 					resource.TestCheckResourceAttr("data.powerflex_os_repository.test", "os_repositories.0.state", OSRepoState),
 					resource.TestCheckResourceAttr("data.powerflex_os_repository.test", "os_repositories.0.created_by", OSRepoCreatedBy),
+				),
+			},
+			{
+				Config: ProviderConfigForTesting + OSRepoDataSourceConfig4,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.powerflex_os_repository.test", "os_repositories.0.id", OSRepoID1),
 				),
 			},
 			{

--- a/templates/guides/datasource_filtering.md
+++ b/templates/guides/datasource_filtering.md
@@ -123,3 +123,28 @@ data "powerflex_example_datasource" "exampleFilter" {
 ```
 []
 ```
+
+## 5. If the filter value is using regular expressions:
+**Config:**
+```
+data "powerflex_example_datasource" "exampleFilter" {
+  filter {
+   id = ["^id-[1-2]$"]
+  }
+}
+```
+**Output:**
+```
+[
+   {
+   id = "id-1"
+   field = false
+   count = 1
+  },
+  {
+   id = "id-2"
+   field = true
+   count = 2
+  }
+]
+```


### PR DESCRIPTION
# Description
Added Regex/Wildcard filtering as an option during the filtering process. This feature is only available for string value input any regex application for integer values will be done via the terraform side

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT

![image](https://github.com/user-attachments/assets/8716cd50-463d-453d-869c-ed65eff59eb5)


![image](https://github.com/user-attachments/assets/bb0cf8a7-8ca8-4e8a-874d-0ce75f03e803)

