### PR TITLE
Regex Filter Defect: Empty input and integer input

### DIFF
--- a/docs/data-sources/nvme_target.md
+++ b/docs/data-sources/nvme_target.md
@@ -87,7 +87,6 @@ data "powerflex_nvme_target" "example" {
     # software_version_info                = ["Version"]
     # maintenance_state                    = ["NoMaintenance"]
     # authentication_error                 = ["None"]
-    # persistent_discovery_controllers_num = [0]
     # system_id                            = ["systemID"]
   }
 }

--- a/examples/data-sources/powerflex_nvme_target/data-source.tf
+++ b/examples/data-sources/powerflex_nvme_target/data-source.tf
@@ -53,7 +53,6 @@ data "powerflex_nvme_target" "example" {
     # software_version_info                = ["Version"]
     # maintenance_state                    = ["NoMaintenance"]
     # authentication_error                 = ["None"]
-    # persistent_discovery_controllers_num = [0]
     # system_id                            = ["systemID"]
   }
 }

--- a/powerflex/helper/helper.go
+++ b/powerflex/helper/helper.go
@@ -389,10 +389,18 @@ func FilterByField(dataSources reflect.Value, fieldValue reflect.Value, field st
 					break
 				}
 
-				//check field value with regex here
-				pattern := regexp.MustCompile(fmt.Sprintf("%v", interFieldValue.Interface()))
+				interFieldRegex := fmt.Sprintf("%v", interFieldValue.Interface())
+				fieldValueRegex := fmt.Sprintf("%v", fieldValueInDataSource.Interface())
 
-				if pattern.MatchString(fmt.Sprintf("%v", fieldValueInDataSource.Interface())) {
+				// Will treat string as regex if "^" and "$" are specified on the first and last index
+				if len(interFieldRegex) > 0 && string(interFieldRegex[0]) == "^" &&
+					string(interFieldRegex[len(interFieldRegex)-1]) == "$" {
+					if regexp.MustCompile(interFieldRegex).MatchString(fieldValueRegex) {
+						filteredData = reflect.Append(filteredData, reflect.ValueOf(dataSource))
+					}
+				}
+
+				if fieldValueInDataSource.Interface() == interFieldValue.Interface() {
 					filteredData = reflect.Append(filteredData, reflect.ValueOf(dataSource))
 				}
 			}
@@ -406,9 +414,19 @@ func FilterByField(dataSources reflect.Value, fieldValue reflect.Value, field st
 				break
 			}
 
-			pattern := regexp.MustCompile(fmt.Sprintf("%v", interFieldValue.Interface()))
+			//check field value is empty to not take in all values
+			interFieldRegex := fmt.Sprintf("%v", interFieldValue.Interface())
+			fieldValueRegex := fmt.Sprintf("%v", fieldValueInDataSource.Interface())
 
-			if pattern.MatchString(fmt.Sprintf("%v", fieldValueInDataSource.Interface())) {
+			// Will treat string as regex if "^" and "$" are specified on the first and last index
+			if len(interFieldRegex) > 0 && string(interFieldRegex[0]) == "^" &&
+				string(interFieldRegex[len(interFieldRegex)-1]) == "$" {
+				if regexp.MustCompile(interFieldRegex).MatchString(fieldValueRegex) {
+					filteredData = reflect.Append(filteredData, reflect.ValueOf(dataSource))
+				}
+			}
+
+			if fieldValueInDataSource.Interface() == interFieldValue.Interface() {
 				filteredData = reflect.Append(filteredData, reflect.ValueOf(dataSource))
 			}
 		}


### PR DESCRIPTION
# Description
Reworked filter to only take in regex if "^" and "$" are specified on the respective first and last index of the user's string input fixing false output.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] AT
- [x] UT