### PR TITLE
SDC Install Use GUID instead of IP

### DIFF
--- a/powerflex/provider/sdc_host_resource_test.go
+++ b/powerflex/provider/sdc_host_resource_test.go
@@ -194,6 +194,7 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 					if FunctionMocker != nil {
 						FunctionMocker.UnPatch()
 					}
+					FunctionMockerSdcHostResourceDelete = Mock((*helper.SdcHostResource).DeleteWindows).Return(nil).Build()
 					FunctionMocker = Mock(helper.GetFirstSystem).Return(nil, fmt.Errorf("Mock error")).Build()
 				},
 				Config:      ProviderConfigForTesting + linuxSdcUt,
@@ -222,7 +223,7 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 						FunctionMockerSdcHostResourceSetParams.UnPatch()
 					}
 
-					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil).Build()
+					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil, nil).Build()
 					FunctionMockerSdcHostResource = Mock((*helper.SdcHostResource).ReadSDCHost).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfigForTesting + windowsSdcSuccessUt,
@@ -241,7 +242,7 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 						FunctionMockerSdcHostResourceSetParams.UnPatch()
 					}
 
-					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil).Build()
+					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil, nil).Build()
 					FunctionMockerSdcHostResource = Mock((*helper.SdcHostResource).ReadSDCHost).Return(sdcWindowsFakeModel, nil).Build()
 					FunctionMockerSdcHostResourceSetParams = Mock((*helper.SdcHostResource).SetSDCParams).Return(fmt.Errorf("mock error")).Build()
 				},
@@ -260,8 +261,8 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 					if FunctionMockerSdcHostResourceSetParams != nil {
 						FunctionMockerSdcHostResourceSetParams.UnPatch()
 					}
-					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil).Build()
-					FunctionMockerSdcHostResourceDelete = Mock((*helper.SdcHostResource).DeleteWindows).Return(nil).Build()
+					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil, nil).Build()
+					FunctionMockerSdcHostResourceSetParams = Mock((*helper.SdcHostResource).SetSDCParams).Return(nil).Build()
 					FunctionMockerSdcHostResource = Mock((*helper.SdcHostResource).ReadSDCHost).Return(sdcWindowsFakeModel,
 						nil).Build()
 				},
@@ -280,7 +281,7 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 						FunctionMockerSdcHostResourceSetParams.UnPatch()
 					}
 
-					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil).Build()
+					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil, nil).Build()
 					FunctionMockerSdcHostResource = Mock((*helper.SdcHostResource).ReadSDCHost).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfigForTesting + windowsSdcSuccessUt,
@@ -299,7 +300,7 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 						FunctionMockerSdcHostResourceSetParams.UnPatch()
 					}
 
-					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil).Build()
+					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil, nil).Build()
 					FunctionMockerSdcHostResource = Mock((*helper.SdcHostResource).ReadSDCHost).Return(sdcWindowsFakeModel, nil).Build()
 				},
 				Config:      ProviderConfigForTesting + linuxSdcUt,
@@ -318,7 +319,7 @@ func TestAccResourceSDCHostUT(t *testing.T) {
 						FunctionMockerSdcHostResourceSetParams.UnPatch()
 					}
 
-					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil).Build()
+					FunctionMocker = Mock((*helper.SdcHostResource).CreateWindows).Return(nil, nil).Build()
 					FunctionMockerSdcHostResource = Mock((*helper.SdcHostResource).ReadSDCHost).Return(sdcWindowsFakeModel, nil).Build()
 				},
 				Config:      ProviderConfigForTesting + osUpdateErrorUt,


### PR DESCRIPTION
<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
- Use GUID instead of IP for validating the SDC has been installed. This is because sometimes the management ip and data ip could be different so IP will not be a good way to validate the SDC after install.  

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit test
- [X] Functional Tests

```
=== RUN   TestAccResourceSDCHostUT
--- PASS: TestAccResourceSDCHostUT (22.59s)
=== RUN   TestAccResourceSDCHostUbuntu
    sdc_host_resource_test.go:352: Skipping this test case for real environment
--- SKIP: TestAccResourceSDCHostUbuntu (0.00s)
=== RUN   TestAccResourceSDCHostsxiNeg
--- PASS: TestAccResourceSDCHostsxiNeg (1.98s)
=== RUN   TestAccResourceSDCHostEsxi
    sdc_host_resource_test.go:638: Skipping this test case for real environment
--- SKIP: TestAccResourceSDCHostEsxi (0.00s)
=== RUN   TestAccResourceSDCHostNegative
--- PASS: TestAccResourceSDCHostNegative (25.43s)
=== RUN   TestAccResourceSDCHostPositive
    sdc_host_resource_win_test.go:56: Skipping this test case for real environment
--- SKIP: TestAccResourceSDCHostPositive (0.00s)
=== RUN   TestAccResourceSDCHostRPMPositive
    sdc_host_resource_win_test.go:81: Skipping this test case for real environment
--- SKIP: TestAccResourceSDCHostRPMPositive (0.00s)
PASS
```