### PR TITLE
Bug Powerflex SDC Volume Mapping

### DIFF
--- a/powerflex/helper/sdc_volumes_mapping_helper.go
+++ b/powerflex/helper/sdc_volumes_mapping_helper.go
@@ -79,6 +79,20 @@ func GetVolValue(vol *goscaleio_types.Volume) (basetypes.ObjectValue, diag.Diagn
 	})
 }
 
+// ReduceMapAndStateVolumes returns the intersection of the mapped and state volumes
+func ReduceMapAndStateVolumes(mappedVolumes []*goscaleio_types.Volume, state []models.SdcVolumeModel) []*goscaleio_types.Volume {
+	var mappedAndStateVolumes []*goscaleio_types.Volume
+	for _, stateVols := range state {
+		for _, vol := range mappedVolumes {
+			if vol.ID == stateVols.VolumeID.ValueString() {
+				mappedAndStateVolumes = append(mappedAndStateVolumes, vol)
+				break
+			}
+		}
+	}
+	return mappedAndStateVolumes
+}
+
 // UpdateSDCVolMapState updates the state
 func UpdateSDCVolMapState(mappedVolumes []*goscaleio_types.Volume, plan *models.SdcVolumeMappingResourceModel, oldState *models.SdcVolumeMappingResourceModel, planVolIds []string) (*models.SdcVolumeMappingResourceModel, diag.Diagnostics) {
 	state := plan

--- a/powerflex/provider/user_resource_test.go
+++ b/powerflex/provider/user_resource_test.go
@@ -93,7 +93,7 @@ func TestAccResourceUser(t *testing.T) {
 					if FunctionMocker != nil {
 						FunctionMocker.UnPatch()
 					}
-					FunctionMocker = Mock((*goscaleio.System).CreateUser).Return(nil, fmt.Errorf("mock error")).Build()
+					FunctionMocker = Mock(helper.CreateSsoUser, OptGeneric).Return(nil, fmt.Errorf("Mock error")).Build()
 				},
 				Config:      ProviderConfigForTesting + UserResourceCreate,
 				ExpectError: regexp.MustCompile(`.*Error creating the user*.`),
@@ -104,10 +104,10 @@ func TestAccResourceUser(t *testing.T) {
 					if FunctionMocker != nil {
 						FunctionMocker.UnPatch()
 					}
-					FunctionMocker = Mock((*goscaleio.System).GetUserByIDName).Return(nil, fmt.Errorf("mock error")).Build()
+					FunctionMocker = Mock((*goscaleio.Client).GetSSOUser).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfigForTesting + UserResourceCreate,
-				ExpectError: regexp.MustCompile(`.*Error fetching the user after creation*.`),
+				ExpectError: regexp.MustCompile(`.*Could not get user by ID user-id*.`),
 			},
 			// Create user Success
 			{


### PR DESCRIPTION
<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
- Fix issue where volumes not part of the terraform state were being unmapped from the SDC when doing a terraform delete with volumes both mapped inside and outside of terraform. 

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
- [x] Manual 