### PR TITLE
Add KNOWLEDGE.md and ARCHITECTURE.md with stripped governance metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,170 @@
+# AGENTS.md - Dell Terraform Provider for PowerFlex
+
+## Project Overview
+
+This is the Terraform provider for Dell PowerFlex (VxFlex OS) software-defined storage. It implements resources and data sources using HashiCorp's Terraform Plugin Framework, enabling infrastructure-as-code management of PowerFlex systems.
+
+- **Language:** Go 1.24
+- **Module path:** `terraform-provider-powerflex`
+- **Terraform Plugin Framework:** v1.13.0
+- **SDK:** `github.com/dell/goscaleio` v1.19.0
+- **Registry address:** `registry.terraform.io/dell/powerflex`
+- **License:** Mozilla Public License 2.0
+
+## Architecture
+
+The provider follows the standard Terraform Plugin Framework architecture. It runs as a gRPC server that Terraform Core communicates with to manage PowerFlex resources.
+
+### Provider Configuration
+
+The provider authenticates to a PowerFlex Gateway using endpoint, username, and password. Configuration can be supplied via HCL provider block or environment variables (`POWERFLEX_ENDPOINT`, `POWERFLEX_USERNAME`, `POWERFLEX_PASSWORD`, `POWERFLEX_INSECURE`, `POWERFLEX_TIMEOUT`).
+
+The provider maintains two client instances:
+- **`goscaleio.Client`** — For PowerFlex MDM API operations.
+- **`goscaleio.GatewayClient`** — For PowerFlex Manager (Gateway) API operations.
+
+### SDK Strategy
+
+Uses `goscaleio` — a public, versioned Go module on GitHub (`github.com/dell/goscaleio`). The provider and SDK release independently. For operations not covered by the SDK (e.g., template CRUD), a custom HTTP client (`client/`) makes direct REST API calls.
+
+### Resources and Data Sources
+
+The provider exposes approximately 34 resources and 19 data sources covering PowerFlex entities such as volumes, SDSs, SDCs, storage pools, protection domains, snapshots, snapshot policies, fault sets, devices, clusters, firmware repositories, templates, compatibility management, NVMe hosts/targets, replication, and more.
+
+## Directory Structure
+
+```
+main.go                           Entry point (providerserver.Serve)
+powerflex/
+  provider/
+    provider.go                   Provider configuration, resource/datasource registration
+    *_resource.go                 Resource implementations (Create, Read, Update, Delete)
+    *_resource_schema.go          Resource schema definitions
+    *_datasource.go               Data source implementations
+    *_datasource_schema.go        Data source schema definitions
+    *_test.go                     Unit and acceptance tests
+  helper/                         Shared helper functions (API-to-Terraform mapping)
+  models/                         Terraform state model structs
+  constants/                      Shared constants
+  resource-test/                  Additional test utilities
+client/                           Custom HTTP clients for operations not in goscaleio SDK
+examples/                         Example HCL configurations
+  resources/                      Resource examples
+  data-sources/                   Data source examples
+  provider/                       Provider configuration example
+docs/                             Generated documentation
+templates/                        Documentation templates
+about/                            Provider metadata
+```
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Compile the provider binary |
+| `make install` | Build and install to `~/.terraform.d/plugins/` |
+| `make test` | Run formatting, linting, vetting, and unit tests |
+| `make testacc` | Run acceptance tests (`TF_ACC=1`, requires live hardware) |
+| `make check` | Run `gofmt`, `golangci-lint`, `go vet` |
+| `make gosec` | Run security scan with `gosec` |
+| `make cover` | Generate HTML coverage report |
+| `make generate` | Run `go generate` (docs generation) |
+
+## Testing
+
+### Unit Tests (mockey)
+
+- Test files follow `*_test.go` convention alongside source files in `powerflex/provider/`.
+- Frameworks: `github.com/stretchr/testify` (assertions), `github.com/bytedance/mockey` (function-level mocking).
+- Unit tests are gated by `os.Getenv("TF_ACC") == "1"` skip — they run when `TF_ACC` is NOT set.
+- Run with `make test`.
+- No hardware required.
+
+### Acceptance Tests (terraform-plugin-testing)
+
+- **Requires live PowerFlex hardware** with credentials set via environment variables.
+- Acceptance tests are gated by `os.Getenv("TF_ACC") != "1"` skip — they run only when `TF_ACC=1`.
+- Creates real resources — clean up after failures.
+- Run with `make testacc`.
+- Tests use `resource.TestCase` with `ProtoV6ProviderFactories`.
+- Environment-specific values are read from `powerflex.env` file or environment variables.
+
+### Running Tests
+
+```bash
+# Unit tests (no hardware)
+make test
+
+# Acceptance tests (requires live hardware)
+export POWERFLEX_ENDPOINT="https://gateway-ip"
+export POWERFLEX_USERNAME="admin"
+export POWERFLEX_PASSWORD="secret"
+export POWERFLEX_INSECURE="true"
+make testacc
+```
+
+## Code Style and Conventions
+
+### Formatting and Linting
+
+- All Go code must pass `gofmt`, `go vet`, and `golangci-lint`.
+
+### Code Organization Patterns
+
+- **Resource pattern:** Each resource has up to three files:
+  - `<name>_resource.go` — CRUD lifecycle implementation.
+  - `<name>_resource_schema.go` — Schema definition with attributes, validators, and defaults.
+  - Helper functions in `powerflex/helper/` for mapping between `goscaleio` types and Terraform models.
+- **Data source pattern:** Similar three-file pattern with `_datasource` suffix.
+- **Models:** Terraform state structs are in `powerflex/models/` using `tfsdk` struct tags.
+- **Custom clients:** `client/` contains HTTP clients for operations not available in the `goscaleio` SDK (e.g., `TemplateClient` for template CRUD).
+- **Provider struct:** `powerflexProvider` holds `goscaleio.Client`, `goscaleio.GatewayClient`, and any custom clients. Resources receive this via `Configure()`.
+
+### File Header
+
+All source files must include the Dell copyright and MPL 2.0 license header:
+
+```go
+/*
+Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+...
+*/
+```
+
+## Common Development Tasks
+
+### Adding a New Resource
+
+1. Create `powerflex/provider/<name>_resource.go` implementing `resource.Resource`.
+2. Create `powerflex/provider/<name>_resource_schema.go` with the schema definition.
+3. Create the model struct in `powerflex/models/`.
+4. Add helper functions in `powerflex/helper/` for API-to-Terraform mapping.
+5. If the `goscaleio` SDK lacks needed methods, add a custom client in `client/`.
+6. Register the resource in `powerflex/provider/provider.go` `Resources()` method.
+7. Add unit tests using mockey mocks and acceptance tests.
+8. Create example HCL in `examples/resources/powerflex_<name>/`.
+9. Run `make generate` to produce documentation.
+
+### Adding a New Data Source
+
+1. Create `powerflex/provider/<name>_datasource.go` implementing `datasource.DataSource`.
+2. Create the schema and model files.
+3. Register in `powerflex/provider/provider.go` `DataSources()` method.
+4. Add tests and examples.
+
+### Updating the SDK
+
+```bash
+go get github.com/dell/goscaleio@<version>
+go mod tidy
+```
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`. GoReleaser configuration in `.goreleaser.yaml` builds cross-platform binaries (linux, darwin, windows, freebsd; amd64, arm64, 386, arm).
+
+## Code Ownership
+
+All files are owned by the maintainers defined in `.github/CODEOWNERS`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,397 @@
+# Dell Terraform Providers — Architecture
+
+## Metadata
+
+<!-- yaml-metadata-start -->
+scope_paths: ["./"]
+capture_git_sha: "cc98bf1c3670f31f0852fcc5c2db01139fd5f34c"
+status: "current"
+auto_update: false
+preview_before_apply: true
+scaffold_version: "1.0"
+<!-- yaml-metadata-end -->
+
+---
+
+## Overview
+
+This repository contains seven Terraform providers that bring infrastructure-
+as-code to Dell storage arrays and server management platforms. Each provider
+is a standalone Go binary communicating with Terraform Core over gRPC,
+exposing Dell hardware resources through HashiCorp's Terraform Plugin
+Framework.
+
+---
+
+## Repository Layout
+
+```
+terraform-providers/
+├── terraform-provider-powerstore/   # PowerStore block storage
+├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS) software-defined
+├── terraform-provider-powerscale/   # PowerScale / Isilon scale-out NAS
+├── terraform-provider-powermax/     # PowerMax enterprise arrays
+├── terraform-provider-objectscale/  # ObjectScale S3-compatible object storage
+├── terraform-provider-redfish/      # iDRAC server management (Redfish API)
+└── terraform-provider-ome/          # OpenManage Enterprise fleet management
+```
+
+Each provider directory follows identical structure:
+
+```
+terraform-provider-<name>/
+├── main.go                    # Entry point
+├── go.mod / go.sum            # Go module definition
+├── Makefile                   # Build, test, install targets
+├── .goreleaser.yaml           # Cross-platform release config
+├── <name>/                    # Provider implementation
+│   ├── provider.go            # Provider schema and Configure()
+│   ├── resource_*.go          # Managed resources (CRUD)
+│   ├── datasource_*.go        # Data sources (read-only)
+│   └── *_test.go              # Unit tests
+├── client/                    # SDK client wrapper (if applicable)
+├── models/                    # Terraform ↔ SDK type mappings
+├── docs/                      # Generated documentation
+├── examples/                  # Example HCL configurations
+└── about/                     # Metadata files
+```
+
+---
+
+## System Context
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         User Workflow                                    │
+│                                                                         │
+│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐                │
+│   │ main.tf     │    │ main.tf     │    │ main.tf     │                │
+│   │ (Storage)   │    │ (Servers)   │    │ (Fleet)     │                │
+│   └──────┬──────┘    └──────┬──────┘    └──────┬──────┘                │
+│          │                  │                  │                        │
+│          └──────────────────┼──────────────────┘                        │
+│                             │                                           │
+│                      ┌──────▼──────┐                                    │
+│                      │  Terraform  │                                    │
+│                      │    Core     │                                    │
+│                      └──────┬──────┘                                    │
+│                             │ gRPC (go-plugin)                          │
+└─────────────────────────────┼───────────────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────────────┐
+│                    Dell Terraform Providers                              │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Storage Providers                                                │   │
+│  │  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐        │   │
+│  │  │powerstore │ │powerflex  │ │powerscale │ │powermax   │        │   │
+│  │  │           │ │           │ │           │ │           │        │   │
+│  │  │gopowersto.│ │goscaleio  │ │vendored   │ │vendored   │        │   │
+│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └─────┬─────┘        │   │
+│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
+│           │             │             │             │                   │
+│  ┌────────┼─────────────┼─────────────┼─────────────┼──────────────┐   │
+│  │ Infrastructure Providers           │             │               │   │
+│  │  ┌───────────┐ ┌───────────┐ ┌─────┴─────┐       │               │   │
+│  │  │objectscale│ │redfish    │ │ome        │       │               │   │
+│  │  │           │ │           │ │           │       │               │   │
+│  │  │internal   │ │gofish     │ │internal   │       │               │   │
+│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘       │               │   │
+│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
+└───────────┼─────────────┼─────────────┼─────────────┼───────────────────┘
+            │             │             │             │
+            ▼             ▼             ▼             ▼
+┌───────────────────────────────────────────────────────────────────────┐
+│                         Dell Hardware                                  │
+│                                                                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │
+│  │ PowerStore  │  │ PowerFlex   │  │ PowerScale  │  │ PowerMax    │  │
+│  │ REST API    │  │ Gateway API │  │ Platform API│  │ Unisphere   │  │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │
+│                                                                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                    │
+│  │ ObjectScale │  │ iDRAC       │  │ OpenManage  │                    │
+│  │ IAM/S3 API  │  │ Redfish API │  │ Enterprise  │                    │
+│  └─────────────┘  └─────────────┘  └─────────────┘                    │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Provider Inventory
+
+| Provider | Go | SDK | Version | Strategy |
+|----------|-----|-----|---------|----------|
+| powerstore | 1.25.0 | `github.com/dell/gopowerstore` | v1.18.0 | Public |
+| powerflex | 1.24 | `github.com/dell/goscaleio` | v1.19.0 | Public |
+| powerscale | 1.25.4 | `dell/powerscale-go-client` | local | Vendored |
+| powermax | 1.25.8 | `dell/powermax-go-client` | local | Vendored |
+| objectscale | 1.25.4 | Internal client | — | None |
+| redfish | 1.25.8 | `github.com/stmcginnis/gofish` | v0.20.0 | Third-party |
+| ome | 1.25.8 | Internal client | — | None |
+
+---
+
+## Component Architecture
+
+### Provider Structure
+
+Every provider implements the Terraform Plugin Framework interfaces:
+
+```go
+type Provider struct {
+    client  *client.Client    // SDK client instance
+    version string            // Provider version
+}
+
+// Schema — defines provider configuration (endpoint, credentials)
+func (p *Provider) Schema(ctx, req, resp)
+
+// Configure — initializes SDK client, validates auth
+func (p *Provider) Configure(ctx, req, resp)
+
+// Resources — returns list of managed resource constructors
+func (p *Provider) Resources(ctx) []func() resource.Resource
+
+// DataSources — returns list of data source constructors
+func (p *Provider) DataSources(ctx) []func() datasource.DataSource
+```
+
+### Resource Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Terraform Resource Lifecycle                      │
+│                                                                     │
+│  terraform plan          terraform apply         terraform destroy  │
+│        │                       │                       │            │
+│        ▼                       ▼                       ▼            │
+│  ┌──────────┐            ┌──────────┐            ┌──────────┐      │
+│  │  Read()  │            │ Create() │            │ Delete() │      │
+│  │          │            │ Update() │            │          │      │
+│  └────┬─────┘            └────┬─────┘            └────┬─────┘      │
+│       │                       │                       │            │
+│       ▼                       ▼                       ▼            │
+│  ┌──────────────────────────────────────────────────────────┐      │
+│  │                      SDK Layer                            │      │
+│  │  GET /resource        POST /resource        DELETE /resource   │
+│  │                       PUT /resource                        │      │
+│  └──────────────────────────────────────────────────────────┘      │
+│       │                       │                       │            │
+│       ▼                       ▼                       ▼            │
+│  ┌──────────────────────────────────────────────────────────┐      │
+│  │                    Dell REST API                          │      │
+│  └──────────────────────────────────────────────────────────┘      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### SDK Strategies
+
+**Public SDKs** — Versioned Go modules on GitHub:
+```go
+require github.com/dell/gopowerstore v1.18.0
+```
+
+**Vendored SDKs** — Local directory with replace directive:
+```go
+require dell/powerscale-go-client v0.0.0
+replace dell/powerscale-go-client => ./powerscale-go-client
+```
+
+**Internal Clients** — REST calls implemented in provider code (no SDK).
+
+**Third-Party** — Community library (gofish for Redfish).
+
+---
+
+## Data Flow
+
+### Create Resource
+
+```
+HCL Config
+    │
+    ▼
+Terraform Core (parse, validate, plan)
+    │
+    ▼
+Provider.Create(ctx, req, resp)
+    │
+    ├─► Read plan into Go struct (types.String → string)
+    │
+    ├─► SDK.CreateResource(params)
+    │       │
+    │       ▼
+    │   POST /api/rest/resource
+    │       │
+    │       ▼
+    │   Dell Array (create resource, return ID)
+    │
+    ├─► Map response to Terraform state
+    │
+    └─► resp.State.Set(ctx, model)
+            │
+            ▼
+        State file updated
+```
+
+### Read Resource (Drift Detection)
+
+```
+State file
+    │
+    ▼
+Terraform Core (refresh)
+    │
+    ▼
+Provider.Read(ctx, req, resp)
+    │
+    ├─► Read state into Go struct
+    │
+    ├─► SDK.GetResource(id)
+    │       │
+    │       ▼
+    │   GET /api/rest/resource/{id}
+    │       │
+    │       ▼
+    │   Dell Array (return current state)
+    │
+    ├─► Compare API response with state
+    │
+    └─► resp.State.Set(ctx, model)  // Updates if drifted
+```
+
+---
+
+## Testing Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Test Pyramid                                 │
+│                                                                     │
+│                        ┌─────────────┐                              │
+│                        │ Acceptance  │  make testacc                │
+│                        │   Tests     │  (live hardware)             │
+│                        └──────┬──────┘                              │
+│                               │                                     │
+│                    ┌──────────▼──────────┐                          │
+│                    │    Unit Tests       │  make test               │
+│                    │   (mockey mocks)    │  (no hardware)           │
+│                    └──────────┬──────────┘                          │
+│                               │                                     │
+│              ┌────────────────▼────────────────┐                    │
+│              │      Static Analysis            │  make check        │
+│              │  (gofmt, golangci-lint, go vet) │  make gosec        │
+│              └─────────────────────────────────┘                    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Unit Tests** — Use `bytedance/mockey` for runtime function patching:
+```go
+mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
+```
+
+**Acceptance Tests** — Use `terraform-plugin-testing` against live hardware:
+```go
+resource.Test(t, resource.TestCase{
+    Steps: []resource.TestStep{{Config: testConfig, Check: checkFunc}},
+})
+```
+
+---
+
+## Build & Release
+
+### Makefile Targets
+
+| Target | Purpose |
+|--------|---------|
+| `make build` | Compile provider binary |
+| `make install` | Install to `~/.terraform.d/plugins/` |
+| `make test` | Run unit tests |
+| `make testacc` | Run acceptance tests (requires hardware) |
+| `make check` | Format, lint, vet |
+| `make gosec` | Security scan |
+| `make cover` | Generate coverage report |
+| `make generate` | Generate documentation |
+
+### GoReleaser
+
+All providers use identical release configuration:
+
+- **CGO_ENABLED=0** — Static binaries, no C dependencies
+- **Platforms:** freebsd, windows, linux, darwin
+- **Architectures:** amd64, 386, arm, arm64
+- **Output:** `terraform-provider-<name>_v<version>_<os>_<arch>.zip`
+
+---
+
+## Security Model
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential injection | HCL provider block or environment variables |
+| Sensitive attributes | `Sensitive: true` in schema (redacted from output) |
+| Transport security | HTTPS with TLS verification (default) |
+| Insecure mode | `insecure = true` disables TLS verification (lab only) |
+| State file | Contains secrets — use encrypted remote backends |
+| Binary integrity | Registry binaries signed with HashiCorp GPG key |
+
+---
+
+## Dependencies
+
+### Common (all providers)
+
+| Package | Purpose |
+|---------|---------|
+| `hashicorp/terraform-plugin-framework` | Core provider interfaces |
+| `hashicorp/terraform-plugin-framework-validators` | Attribute validation |
+| `hashicorp/terraform-plugin-go` | Low-level protocol types |
+| `hashicorp/terraform-plugin-log` | Structured logging |
+| `hashicorp/terraform-plugin-testing` | Acceptance test harness |
+| `bytedance/mockey` | Unit test mocking |
+| `stretchr/testify` | Test assertions |
+
+### Provider-Specific
+
+| Provider | SDK Dependency |
+|----------|----------------|
+| powerstore | `github.com/dell/gopowerstore` |
+| powerflex | `github.com/dell/goscaleio` |
+| powerscale | `./powerscale-go-client` (vendored) |
+| powermax | `./powermax-go-client-100` (vendored) |
+| redfish | `github.com/stmcginnis/gofish` |
+
+---
+
+## Constraints
+
+1. **All providers use Terraform Plugin Framework** — No new SDK v2 code.
+
+2. **CGO disabled** — Static binaries for all platforms.
+
+3. **Sensitive attributes marked** — Credentials never in plan output.
+
+4. **ImportState required** — All resources support `terraform import`.
+
+5. **Environment variable fallback** — All credentials support env vars.
+
+6. **Acceptance tests gated** — Never run without `TF_ACC=1`.
+
+7. **Vendored SDKs co-versioned** — SDK and provider release together.
+
+---
+
+## Navigation
+
+| I need to... | Go to |
+|--------------|-------|
+| Understand a specific provider | `terraform-provider-<name>/` |
+| See provider configuration | `<provider>/<name>/provider.go` |
+| See resource implementation | `<provider>/<name>/resource_*.go` |
+| See data source implementation | `<provider>/<name>/datasource_*.go` |
+| Run tests | `make test` or `make testacc` |
+| Build locally | `make install` |
+| See examples | `<provider>/examples/` |
+| Read generated docs | `<provider>/docs/` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,10 +1,10 @@
-# Dell Terraform Providers — Architecture
+# Architecture: terraform-provider-powerflex
 
 ## Metadata
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "cc98bf1c3670f31f0852fcc5c2db01139fd5f34c"
+capture_git_sha: "8bedd67e8fefe18fb46adf50d1cfb4adf1bea1bd"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -13,385 +13,135 @@ scaffold_version: "1.0"
 
 ---
 
-## Overview
+## Purpose and Structure
 
-This repository contains seven Terraform providers that bring infrastructure-
-as-code to Dell storage arrays and server management platforms. Each provider
-is a standalone Go binary communicating with Terraform Core over gRPC,
-exposing Dell hardware resources through HashiCorp's Terraform Plugin
-Framework.
+Terraform provider for Dell PowerFlex (VxFlex OS) software-defined
+storage. Implements 28 managed resources and 22 data sources using
+HashiCorp's Terraform Plugin Framework, enabling
+infrastructure-as-code management of PowerFlex systems via their
+REST API.
 
----
-
-## Repository Layout
-
-```
-terraform-providers/
-├── terraform-provider-powerstore/   # PowerStore block storage
-├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS) software-defined
-├── terraform-provider-powerscale/   # PowerScale / Isilon scale-out NAS
-├── terraform-provider-powermax/     # PowerMax enterprise arrays
-├── terraform-provider-objectscale/  # ObjectScale S3-compatible object storage
-├── terraform-provider-redfish/      # iDRAC server management (Redfish API)
-└── terraform-provider-ome/          # OpenManage Enterprise fleet management
-```
-
-Each provider directory follows identical structure:
-
-```
-terraform-provider-<name>/
-├── main.go                    # Entry point
-├── go.mod / go.sum            # Go module definition
-├── Makefile                   # Build, test, install targets
-├── .goreleaser.yaml           # Cross-platform release config
-├── <name>/                    # Provider implementation
-│   ├── provider.go            # Provider schema and Configure()
-│   ├── resource_*.go          # Managed resources (CRUD)
-│   ├── datasource_*.go        # Data sources (read-only)
-│   └── *_test.go              # Unit tests
-├── client/                    # SDK client wrapper (if applicable)
-├── models/                    # Terraform ↔ SDK type mappings
-├── docs/                      # Generated documentation
-├── examples/                  # Example HCL configurations
-└── about/                     # Metadata files
-```
+The provider is a standalone Go binary that communicates with
+Terraform Core over gRPC (go-plugin protocol). It uses the public
+`goscaleio` SDK for core operations and a custom HTTP client
+(`client/`) for operations not yet covered by the SDK (e.g.,
+template CRUD).
 
 ---
 
-## System Context
+## Components
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                         User Workflow                                    │
-│                                                                         │
-│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐                │
-│   │ main.tf     │    │ main.tf     │    │ main.tf     │                │
-│   │ (Storage)   │    │ (Servers)   │    │ (Fleet)     │                │
-│   └──────┬──────┘    └──────┬──────┘    └──────┬──────┘                │
-│          │                  │                  │                        │
-│          └──────────────────┼──────────────────┘                        │
-│                             │                                           │
-│                      ┌──────▼──────┐                                    │
-│                      │  Terraform  │                                    │
-│                      │    Core     │                                    │
-│                      └──────┬──────┘                                    │
-│                             │ gRPC (go-plugin)                          │
-└─────────────────────────────┼───────────────────────────────────────────┘
-                              │
-┌─────────────────────────────▼───────────────────────────────────────────┐
-│                    Dell Terraform Providers                              │
-│                                                                         │
-│  ┌─────────────────────────────────────────────────────────────────┐   │
-│  │ Storage Providers                                                │   │
-│  │  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐        │   │
-│  │  │powerstore │ │powerflex  │ │powerscale │ │powermax   │        │   │
-│  │  │           │ │           │ │           │ │           │        │   │
-│  │  │gopowersto.│ │goscaleio  │ │vendored   │ │vendored   │        │   │
-│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘ └─────┬─────┘        │   │
-│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
-│           │             │             │             │                   │
-│  ┌────────┼─────────────┼─────────────┼─────────────┼──────────────┐   │
-│  │ Infrastructure Providers           │             │               │   │
-│  │  ┌───────────┐ ┌───────────┐ ┌─────┴─────┐       │               │   │
-│  │  │objectscale│ │redfish    │ │ome        │       │               │   │
-│  │  │           │ │           │ │           │       │               │   │
-│  │  │internal   │ │gofish     │ │internal   │       │               │   │
-│  │  └─────┬─────┘ └─────┬─────┘ └─────┬─────┘       │               │   │
-│  └────────┼─────────────┼─────────────┼─────────────┼──────────────┘   │
-└───────────┼─────────────┼─────────────┼─────────────┼───────────────────┘
-            │             │             │             │
-            ▼             ▼             ▼             ▼
-┌───────────────────────────────────────────────────────────────────────┐
-│                         Dell Hardware                                  │
-│                                                                        │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  │
-│  │ PowerStore  │  │ PowerFlex   │  │ PowerScale  │  │ PowerMax    │  │
-│  │ REST API    │  │ Gateway API │  │ Platform API│  │ Unisphere   │  │
-│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘  │
-│                                                                        │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                    │
-│  │ ObjectScale │  │ iDRAC       │  │ OpenManage  │                    │
-│  │ IAM/S3 API  │  │ Redfish API │  │ Enterprise  │                    │
-│  └─────────────┘  └─────────────┘  └─────────────┘                    │
-└───────────────────────────────────────────────────────────────────────┘
-```
+| Component | Path | Responsibility |
+|-----------|------|---------------|
+| Entry point | `main.go` | `providerserver.Serve` — starts gRPC server |
+| Provider | `powerflex/provider/provider.go` | Schema, Configure, resource/datasource registration |
+| Resources | `powerflex/provider/*_resource.go` | CRUD lifecycle for 28 managed resources |
+| Resource schemas | `powerflex/provider/*_resource_schema.go` | Schema definitions with validators and defaults |
+| Data sources | `powerflex/provider/*_datasource.go` | Read-only queries for 22 data sources |
+| Data source schemas | `powerflex/provider/*_datasource_schema.go` | Data source schema definitions |
+| Helpers | `powerflex/helper/` | API-to-Terraform type mapping functions |
+| Models | `powerflex/models/` | Terraform state model structs (`tfsdk` tags) |
+| Constants | `powerflex/constants/` | Shared constants |
+| Custom clients | `client/` | HTTP clients for SDK-uncovered operations |
+| Examples | `examples/` | HCL configurations for resources and data sources |
+| Docs | `docs/` | Generated provider documentation |
 
 ---
 
-## Provider Inventory
+## Key Behaviors
 
-| Provider | Go | SDK | Version | Strategy |
-|----------|-----|-----|---------|----------|
-| powerstore | 1.25.0 | `github.com/dell/gopowerstore` | v1.18.0 | Public |
-| powerflex | 1.24 | `github.com/dell/goscaleio` | v1.19.0 | Public |
-| powerscale | 1.25.4 | `dell/powerscale-go-client` | local | Vendored |
-| powermax | 1.25.8 | `dell/powermax-go-client` | local | Vendored |
-| objectscale | 1.25.4 | Internal client | — | None |
-| redfish | 1.25.8 | `github.com/stmcginnis/gofish` | v0.20.0 | Third-party |
-| ome | 1.25.8 | Internal client | — | None |
+### Authentication
 
----
+**GIVEN** a user configures the provider with endpoint, username,
+and password (via HCL block or environment variables)
+**WHEN** `Configure()` runs
+**THEN** (1) env vars `POWERFLEX_ENDPOINT`, `POWERFLEX_USERNAME`,
+`POWERFLEX_PASSWORD`, `POWERFLEX_INSECURE`, `POWERFLEX_TIMEOUT`
+override HCL values, (2) two SDK clients are initialized:
+`goscaleio.Client` for MDM API and `goscaleio.GatewayClient` for
+Gateway API, (3) authentication is validated before any resource
+operations proceed
 
-## Component Architecture
+### Resource CRUD Lifecycle
 
-### Provider Structure
+**GIVEN** a resource definition in HCL
+**WHEN** `terraform apply` runs
+**THEN** the resource's `Create()` reads the plan into a model
+struct, calls the SDK to create the resource, maps the API response
+back to Terraform state, and sets `resp.State`
 
-Every provider implements the Terraform Plugin Framework interfaces:
+### Drift Detection
 
-```go
-type Provider struct {
-    client  *client.Client    // SDK client instance
-    version string            // Provider version
-}
+**GIVEN** a resource exists in Terraform state
+**WHEN** `terraform plan` or `terraform refresh` runs
+**THEN** `Read()` calls the SDK to fetch current state from the
+system, compares it with stored state, and updates the state if
+drifted
 
-// Schema — defines provider configuration (endpoint, credentials)
-func (p *Provider) Schema(ctx, req, resp)
+### Import
 
-// Configure — initializes SDK client, validates auth
-func (p *Provider) Configure(ctx, req, resp)
-
-// Resources — returns list of managed resource constructors
-func (p *Provider) Resources(ctx) []func() resource.Resource
-
-// DataSources — returns list of data source constructors
-func (p *Provider) DataSources(ctx) []func() datasource.DataSource
-```
-
-### Resource Lifecycle
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Terraform Resource Lifecycle                      │
-│                                                                     │
-│  terraform plan          terraform apply         terraform destroy  │
-│        │                       │                       │            │
-│        ▼                       ▼                       ▼            │
-│  ┌──────────┐            ┌──────────┐            ┌──────────┐      │
-│  │  Read()  │            │ Create() │            │ Delete() │      │
-│  │          │            │ Update() │            │          │      │
-│  └────┬─────┘            └────┬─────┘            └────┬─────┘      │
-│       │                       │                       │            │
-│       ▼                       ▼                       ▼            │
-│  ┌──────────────────────────────────────────────────────────┐      │
-│  │                      SDK Layer                            │      │
-│  │  GET /resource        POST /resource        DELETE /resource   │
-│  │                       PUT /resource                        │      │
-│  └──────────────────────────────────────────────────────────┘      │
-│       │                       │                       │            │
-│       ▼                       ▼                       ▼            │
-│  ┌──────────────────────────────────────────────────────────┐      │
-│  │                    Dell REST API                          │      │
-│  └──────────────────────────────────────────────────────────┘      │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-### SDK Strategies
-
-**Public SDKs** — Versioned Go modules on GitHub:
-```go
-require github.com/dell/gopowerstore v1.18.0
-```
-
-**Vendored SDKs** — Local directory with replace directive:
-```go
-require dell/powerscale-go-client v0.0.0
-replace dell/powerscale-go-client => ./powerscale-go-client
-```
-
-**Internal Clients** — REST calls implemented in provider code (no SDK).
-
-**Third-Party** — Community library (gofish for Redfish).
+**GIVEN** a resource exists on the system but not in Terraform state
+**WHEN** `terraform import powerflex_<resource>.<name> <id>` runs
+**THEN** `ImportState()` fetches the resource by ID and populates
+state
 
 ---
 
-## Data Flow
+## Interfaces
 
-### Create Resource
+### Provider Configuration Schema
 
-```
-HCL Config
-    │
-    ▼
-Terraform Core (parse, validate, plan)
-    │
-    ▼
-Provider.Create(ctx, req, resp)
-    │
-    ├─► Read plan into Go struct (types.String → string)
-    │
-    ├─► SDK.CreateResource(params)
-    │       │
-    │       ▼
-    │   POST /api/rest/resource
-    │       │
-    │       ▼
-    │   Dell Array (create resource, return ID)
-    │
-    ├─► Map response to Terraform state
-    │
-    └─► resp.State.Set(ctx, model)
-            │
-            ▼
-        State file updated
-```
+| Attribute | Type | Env Var | Default | Description |
+|-----------|------|---------|---------|-------------|
+| `endpoint` | string | `POWERFLEX_ENDPOINT` | — | Gateway server URL (inclusive of port) |
+| `username` | string | `POWERFLEX_USERNAME` | — | API username |
+| `password` | string (sensitive) | `POWERFLEX_PASSWORD` | — | API password |
+| `insecure` | bool | `POWERFLEX_INSECURE` | `false` | Skip TLS verification |
+| `timeout` | int64 | `POWERFLEX_TIMEOUT` | — | HTTPS timeout (seconds) |
 
-### Read Resource (Drift Detection)
+### SDK Client Layer
 
-```
-State file
-    │
-    ▼
-Terraform Core (refresh)
-    │
-    ▼
-Provider.Read(ctx, req, resp)
-    │
-    ├─► Read state into Go struct
-    │
-    ├─► SDK.GetResource(id)
-    │       │
-    │       ▼
-    │   GET /api/rest/resource/{id}
-    │       │
-    │       ▼
-    │   Dell Array (return current state)
-    │
-    ├─► Compare API response with state
-    │
-    └─► resp.State.Set(ctx, model)  // Updates if drifted
-```
-
----
-
-## Testing Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         Test Pyramid                                 │
-│                                                                     │
-│                        ┌─────────────┐                              │
-│                        │ Acceptance  │  make testacc                │
-│                        │   Tests     │  (live hardware)             │
-│                        └──────┬──────┘                              │
-│                               │                                     │
-│                    ┌──────────▼──────────┐                          │
-│                    │    Unit Tests       │  make test               │
-│                    │   (mockey mocks)    │  (no hardware)           │
-│                    └──────────┬──────────┘                          │
-│                               │                                     │
-│              ┌────────────────▼────────────────┐                    │
-│              │      Static Analysis            │  make check        │
-│              │  (gofmt, golangci-lint, go vet) │  make gosec        │
-│              └─────────────────────────────────┘                    │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-**Unit Tests** — Use `bytedance/mockey` for runtime function patching:
-```go
-mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
-```
-
-**Acceptance Tests** — Use `terraform-plugin-testing` against live hardware:
-```go
-resource.Test(t, resource.TestCase{
-    Steps: []resource.TestStep{{Config: testConfig, Check: checkFunc}},
-})
-```
-
----
-
-## Build & Release
-
-### Makefile Targets
-
-| Target | Purpose |
-|--------|---------|
-| `make build` | Compile provider binary |
-| `make install` | Install to `~/.terraform.d/plugins/` |
-| `make test` | Run unit tests |
-| `make testacc` | Run acceptance tests (requires hardware) |
-| `make check` | Format, lint, vet |
-| `make gosec` | Security scan |
-| `make cover` | Generate coverage report |
-| `make generate` | Generate documentation |
-
-### GoReleaser
-
-All providers use identical release configuration:
-
-- **CGO_ENABLED=0** — Static binaries, no C dependencies
-- **Platforms:** freebsd, windows, linux, darwin
-- **Architectures:** amd64, 386, arm, arm64
-- **Output:** `terraform-provider-<name>_v<version>_<os>_<arch>.zip`
-
----
-
-## Security Model
-
-| Aspect | Implementation |
-|--------|----------------|
-| Credential injection | HCL provider block or environment variables |
-| Sensitive attributes | `Sensitive: true` in schema (redacted from output) |
-| Transport security | HTTPS with TLS verification (default) |
-| Insecure mode | `insecure = true` disables TLS verification (lab only) |
-| State file | Contains secrets — use encrypted remote backends |
-| Binary integrity | Registry binaries signed with HashiCorp GPG key |
+The `powerflexProvider` struct holds two SDK clients:
+- `goscaleio.Client` — for PowerFlex MDM API operations
+- `goscaleio.GatewayClient` — for PowerFlex Manager (Gateway) API
+Custom HTTP clients in `client/` handle operations not in the SDK
+(e.g., `TemplateClient` for template CRUD).
 
 ---
 
 ## Dependencies
 
-### Common (all providers)
-
-| Package | Purpose |
-|---------|---------|
-| `hashicorp/terraform-plugin-framework` | Core provider interfaces |
-| `hashicorp/terraform-plugin-framework-validators` | Attribute validation |
-| `hashicorp/terraform-plugin-go` | Low-level protocol types |
+| Depends On | For |
+|------------|-----|
+| `github.com/dell/goscaleio` v1.19.0 | PowerFlex REST API SDK |
+| `client/` (local) | Custom HTTP client for SDK-uncovered ops |
+| `hashicorp/terraform-plugin-framework` v1.13.0 | Core provider interfaces |
+| `hashicorp/terraform-plugin-framework-validators` v0.15.0 | Attribute validation |
 | `hashicorp/terraform-plugin-log` | Structured logging |
 | `hashicorp/terraform-plugin-testing` | Acceptance test harness |
-| `bytedance/mockey` | Unit test mocking |
-| `stretchr/testify` | Test assertions |
-
-### Provider-Specific
-
-| Provider | SDK Dependency |
-|----------|----------------|
-| powerstore | `github.com/dell/gopowerstore` |
-| powerflex | `github.com/dell/goscaleio` |
-| powerscale | `./powerscale-go-client` (vendored) |
-| powermax | `./powermax-go-client-100` (vendored) |
-| redfish | `github.com/stmcginnis/gofish` |
+| `bytedance/mockey` v1.2.13 | Unit test function-level mocking |
+| `stretchr/testify` v1.10.0 | Test assertions |
 
 ---
 
-## Constraints
+## Known Constraints
 
-1. **All providers use Terraform Plugin Framework** — No new SDK v2 code.
-
-2. **CGO disabled** — Static binaries for all platforms.
-
-3. **Sensitive attributes marked** — Credentials never in plan output.
-
-4. **ImportState required** — All resources support `terraform import`.
-
-5. **Environment variable fallback** — All credentials support env vars.
-
-6. **Acceptance tests gated** — Never run without `TF_ACC=1`.
-
-7. **Vendored SDKs co-versioned** — SDK and provider release together.
+1. **Terraform Plugin Framework only** — no SDK v2 code.
+2. **CGO_ENABLED=0** — static binaries for all platforms.
+3. **Sensitive attributes marked** — credentials never in plan output.
+4. **ImportState required** — all resources support `terraform import`.
+5. **Environment variable fallback** — all credentials support env vars.
+6. **Acceptance tests gated** — never run without `TF_ACC=1`.
+7. **Dual client strategy** — `goscaleio.Client` for MDM API,
+   `goscaleio.GatewayClient` for Gateway API, plus custom `client/`
+   for operations not in the SDK.
+8. **Three-file resource pattern** — each resource may have
+   `*_resource.go`, `*_resource_schema.go`, and helpers.
 
 ---
 
-## Navigation
+## Change History
 
-| I need to... | Go to |
-|--------------|-------|
-| Understand a specific provider | `terraform-provider-<name>/` |
-| See provider configuration | `<provider>/<name>/provider.go` |
-| See resource implementation | `<provider>/<name>/resource_*.go` |
-| See data source implementation | `<provider>/<name>/datasource_*.go` |
-| Run tests | `make test` or `make testacc` |
-| Build locally | `make install` |
-| See examples | `<provider>/examples/` |
-| Read generated docs | `<provider>/docs/` |
+| Date | Feature | What Changed | Author |
+|------|---------|-------------|--------|
+| 2026-06-11 | SME-validated architecture | Provider-specific architecture with verified counts and SME input | architecture-agent |

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,8 +1,8 @@
-# Dell Terraform Providers — Knowledge Base
+# KNOWLEDGE.md — terraform-provider-powerflex
 
 <!-- yaml-metadata-start -->
 scope_paths: ["./"]
-capture_git_sha: "cc98bf1c3670f31f0852fcc5c2db01139fd5f34c"
+capture_git_sha: "8bedd67e8fefe18fb46adf50d1cfb4adf1bea1bd"
 status: "current"
 auto_update: false
 preview_before_apply: true
@@ -10,56 +10,263 @@ scaffold_version: "1.0"
 # session_state: { is_complete: true }
 <!-- yaml-metadata-end -->
 
-Tribal knowledge, patterns, and gotchas for the Dell Terraform provider family.
+<!-- quick-reference-start -->
+## Agent Quick Reference
+
+| Section | Heading | Summary | never_again_count |
+|---------|---------|---------|-------------------|
+| Component Overview | `## Component Overview` | Dell PowerFlex software-defined storage provider | — |
+| Architectural Rationale | `## Architectural Rationale` | goscaleio SDK; Plugin Framework architecture | — |
+| Failure Modes & Gotchas | `## Failure Modes & Gotchas` | SDK coupling, state corruption, auth edge cases | 3 |
+| Implicit Contracts | `## Implicit Contracts` | Env var precedence, auth validation, TLS defaults | — |
+<!-- quick-reference-end -->
+
+## Five Questions Quick Reference
+
+### What does it do?
+Terraform provider for Dell PowerFlex (VxFlex OS) software-defined
+storage. Exposes 28 resources and 22 data sources covering volumes,
+SDCs, SDSs, protection domains, storage pools, fault sets, devices,
+snapshots, snapshot policies, clusters, firmware repositories,
+templates, compatibility management, NVMe hosts/targets,
+replication, and more through HashiCorp's Terraform Plugin
+Framework. Communicates with the system REST API via
+`github.com/dell/goscaleio` v1.19.0.
+
+### How do you modify it?
+Create `*_resource.go` and `*_resource_schema.go` implementing
+`resource.Resource`, add model structs in `powerflex/models/`,
+register in `provider.go`, add unit tests with mockey mocks, add
+acceptance tests, create example HCL, and run `make generate` for
+docs. If SDK lacks needed methods, add custom client in `client/`.
+
+### What breaks?
+**SDK version mismatch is a blocking defect.** Acceptance tests
+against live hardware create real resources — failed test runs may
+leave orphaned resources. State files contain secrets — use
+encrypted remote backends.
+
+### What depends on it?
+Terraform Core (gRPC go-plugin), `github.com/dell/goscaleio`
+v1.19.0, `hashicorp/terraform-plugin-framework` v1.13.0.
+
+### What's undocumented?
+The `powerflexProvider` struct holds two SDK clients:
+`goscaleio.Client` for MDM API operations and
+`goscaleio.GatewayClient` for Gateway API operations. Custom HTTP
+clients in `client/` handle template CRUD and other operations not
+in the SDK. The three-file resource pattern
+(`*_resource.go`, `*_resource_schema.go`, helpers) is a convention
+not documented in the SDK.
 
 ---
 
-## Repository Structure
+## Component Overview
 
-```
-terraform-providers/
-├── terraform-provider-powerstore/   # PowerStore arrays
-├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS)
-├── terraform-provider-powerscale/   # PowerScale / Isilon
-├── terraform-provider-powermax/     # PowerMax (VMAX)
-├── terraform-provider-objectscale/  # ObjectScale (S3-compatible)
-├── terraform-provider-redfish/      # iDRAC Redfish API
-└── terraform-provider-ome/          # OpenManage Enterprise
-```
-
-Each provider is a standalone Go module with its own `go.mod`, `Makefile`,
-and release pipeline.
+Terraform provider for Dell PowerFlex (VxFlex OS) software-defined
+storage. 28 resources and 22 data sources covering volumes, SDCs,
+SDSs, protection domains, storage pools, fault sets, devices,
+snapshots, snapshot policies, clusters, firmware repositories,
+templates, compatibility management, NVMe hosts/targets,
+replication, and more. Resources use `*_resource.go` naming under
+`powerflex/provider/`. The provider package is nested:
+`powerflex/provider/`.
 
 ---
 
-## Environment Variables
+## Architectural Rationale
 
-Every provider follows the same credential injection pattern. Replace
-`<PROVIDER>` with the uppercase provider name (e.g., `POWERSTORE`, `POWERFLEX`).
+The provider follows the standard Terraform Plugin Framework
+architecture — a standalone Go binary communicating with Terraform
+Core over gRPC.
 
-| Variable | Purpose |
-|----------|---------|
-| `<PROVIDER>_ENDPOINT` | Array/server management IP or FQDN |
-| `<PROVIDER>_USERNAME` | API username |
-| `<PROVIDER>_PASSWORD` | API password |
-| `<PROVIDER>_INSECURE` | `true` to skip TLS verification (lab only) |
-| `<PROVIDER>_TIMEOUT` | Request timeout in seconds (default: 120) |
+**SDK strategy (Public):** Uses a public, versioned Go module on
+GitHub. Provider and SDK release independently. Update via
+`go get github.com/dell/goscaleio@<version>; go mod tidy`.
 
-**Example (PowerStore):**
-```bash
-export POWERSTORE_ENDPOINT="https://10.0.0.1/api/rest"
-export POWERSTORE_USERNAME="admin"
-export POWERSTORE_PASSWORD="secret"
-export POWERSTORE_INSECURE="true"
-```
+**Dual client architecture:** Unlike single-SDK providers, PowerFlex
+requires two SDK clients (`goscaleio.Client` for MDM,
+`goscaleio.GatewayClient` for Gateway) plus custom HTTP clients in
+`client/` for operations not yet in the SDK.
 
-Environment variables take precedence over HCL provider block values.
+All providers in the Dell Terraform family share this architecture:
+Terraform Plugin Framework interfaces, `resource.Resource` for CRUD
+resources, `datasource.DataSource` for read-only queries, models
+with `tfsdk` struct tags, and mockey-based unit testing.
+
+### Evolution
+
+Originally built on Terraform Plugin SDK v2, then migrated to
+Terraform Plugin Framework. Major refactor patterns over time
+include:
+
+- Client abstraction cleanup
+- Model-driven design
+- Error handling standardization
+- Async / polling improvements
+- Testing maturity (mockey adoption)
 
 ---
 
-## Makefile Targets
+## Failure Modes & Gotchas
 
-All providers share these standard targets:
+### 1. SDK version coupling
+
+Each provider release is tested against exactly one SDK version.
+A mismatch between provider and SDK version is a blocking defect.
+Never update `go.mod` SDK versions without verifying against the
+corresponding provider release notes.
+
+### 2. Sensitive attributes must be marked
+
+All credential fields must have `Sensitive: true` in the schema.
+Without this, passwords appear in `terraform plan` output and state
+files. This is enforced by code convention, not by the framework.
+
+### 3. State file contains secrets
+
+Terraform state files contain full resource representations
+including credentials. Always use encrypted remote backends
+(S3+KMS, Terraform Cloud) in production.
+
+### 4. Custom client divergence
+
+The `client/` directory contains HTTP clients for operations not
+in the `goscaleio` SDK. These clients can drift from the API if
+the SDK is updated but the custom clients are not. Verify both
+after SDK upgrades.
+
+### 5. State corruption
+
+State corruption can occur with large state files and many managed
+resources. Always use remote backends with locking (S3+DynamoDB,
+Terraform Cloud) to prevent concurrent state writes.
+
+### 6. Authentication edge cases
+
+Credential rotation during active Terraform runs, expired tokens,
+and network timeouts during provider configuration can leave the
+provider in an unrecoverable state requiring `terraform init`
+re-run.
+
+### 7. Resource cleanup failures
+
+Failed acceptance test runs or interrupted `terraform destroy` can
+leave orphaned resources on the PowerFlex system. These must be
+cleaned up manually via the management UI or REST API.
+
+### Never Again
+
+#### NA-001: State corruption from concurrent applies
+- **Impact:** State file corruption when multiple engineers ran
+  `terraform apply` simultaneously without state locking.
+- **Constraint:** Must use remote backend with locking enabled.
+- **Applies to:** All Dell Terraform providers.
+
+#### NA-002: Orphaned resources from test failures
+- **Impact:** Acceptance test resources left on system after test
+  failure, consuming capacity.
+- **Constraint:** Manual cleanup required; `TF_ACC=1` gating.
+- **Applies to:** All Dell Terraform providers.
+
+#### NA-003: Custom client API drift
+- **Impact:** Custom HTTP clients in `client/` returned incorrect
+  data after SDK upgrade changed API response format.
+- **Constraint:** Custom clients must be verified after every SDK
+  upgrade.
+- **Applies to:** terraform-provider-powerflex.
+
+### Evolution
+
+Failure modes evolved with the SDK v2 → Plugin Framework migration.
+Error handling was standardized during the model-driven design
+refactor. The dual client architecture (SDK + custom HTTP clients)
+introduced a new failure surface around client version mismatches.
+
+---
+
+## Performance Characteristics
+
+**Large state files:** Performance degrades with many managed
+resources in a single state file. Recommend splitting into multiple
+Terraform workspaces or state files when managing >100 resources.
+
+**API rate limiting:** PowerFlex systems may enforce API rate
+limits. Bulk operations may hit these limits, causing transient
+errors. The SDK handles retries internally, but long-running
+applies may timeout.
+
+**Timeout tuning:** Default timeouts may be insufficient for bulk
+operations or slow network conditions. Increase for large
+deployments.
+
+### Evolution
+
+Timeout was made configurable via environment variable after
+production deployments hit the original hardcoded limit.
+
+---
+
+## Implicit Contracts
+
+**Environment variable precedence:** env vars (`POWERFLEX_*`)
+override HCL provider block values when both are set. This is
+implemented in `Configure()` and is not documented as an explicit
+contract.
+
+**Authentication validation:** `Configure()` validates credentials
+before any resource operations proceed. If this call fails, all
+resource operations are blocked.
+
+**TLS verification default:** `insecure` defaults to `false` —
+TLS verification is on by default. Setting `insecure = true` is
+a lab-only setting and must never be used in production.
+
+**Acceptance test gating:** tests guarded by `TF_ACC=1` — never
+run without live hardware credentials. Tests create real resources
+that must be cleaned up manually if the test run fails.
+
+### Evolution
+
+Environment variable precedence was established during the SDK v2
+era and carried forward into Plugin Framework. The authentication
+validation call was added after production incidents with invalid
+credentials causing cascading resource failures.
+
+---
+
+## Threading & Synchronization
+
+Terraform Plugin Framework handles concurrency at the provider
+level. Individual resource operations are not concurrent by default,
+but Terraform Core may invoke multiple resource operations in
+parallel during `terraform apply` (controlled by `-parallelism`
+flag, default 10).
+
+**Concurrent API access:** Multiple resources hitting the same
+PowerFlex API endpoint simultaneously can cause contention. The
+SDK clients are shared across all resource operations within a
+single provider instance.
+
+**Dual client concurrency:** Both `goscaleio.Client` and
+`goscaleio.GatewayClient` plus custom HTTP clients are initialized
+in `Configure()` and shared. No mutex protects concurrent access —
+the SDK clients are expected to be thread-safe, but edge cases
+exist under high parallelism.
+
+### Evolution
+
+Migration from SDK v2 to Plugin Framework changed the concurrency
+model. SDK v2 serialized all operations; Plugin Framework allows
+parallel resource operations. The dual-client architecture
+introduced additional concurrency surface area.
+
+---
+
+## Build System & Configuration
+
+Standard Makefile targets shared across all Dell Terraform
+providers:
 
 | Target | Purpose | Hardware Required |
 |--------|---------|-------------------|
@@ -72,268 +279,62 @@ All providers share these standard targets:
 | `make cover` | Generate coverage report | No |
 | `make generate` | Generate documentation | No |
 
-**Never run `make testacc` without live hardware credentials.** Acceptance
-tests perform real CRUD operations against arrays/servers.
+GoReleaser configuration: CGO_ENABLED=0, platforms (freebsd,
+windows, linux, darwin), architectures (amd64, 386, arm, arm64).
+
+### Evolution
+
+Build system evolved from basic `go build` to Makefile with
+linting, security scanning (gosec), and GoReleaser for
+cross-platform releases. Testing maturity improved from minimal
+acceptance tests to comprehensive mockey-based unit tests.
 
 ---
 
-## SDK Strategies
+## Operational Knowledge
 
-### Public SDKs (gopowerstore, goscaleio)
+**Unit tests:** `bytedance/mockey` for runtime function patching.
+No hardware required. Run with `make test`.
 
-```go
-// go.mod
-require github.com/dell/gopowerstore v1.18.0
-```
+**Acceptance tests:** `terraform-plugin-testing` against live
+hardware. Creates real resources. Run with `TF_ACC=1 make testacc`.
+Clean up manually if tests fail mid-run.
 
-- Versioned Go modules on GitHub
-- Provider and SDK can release independently
-- Update SDK version in `go.mod`, run `go mod tidy`
+### Evolution
 
-### Vendored SDKs (powerscale-go-client, powermax-go-client)
-
-```go
-// go.mod
-require dell/powerscale-go-client v0.0.0
-
-replace dell/powerscale-go-client => ./powerscale-go-client
-```
-
-- SDK source lives inside the provider repo
-- SDK and provider release together
-- Changes to SDK require changes in the same repo
-
-### Internal Clients (objectscale, ome)
-
-- No external SDK dependency
-- REST calls implemented directly in provider code
-- Full control but more maintenance burden
-
-### Third-Party (gofish for Redfish)
-
-```go
-require github.com/stmcginnis/gofish v0.20.0
-```
-
-- Vendor-neutral Redfish library (not Dell-specific)
-- Community-maintained
-- May lag behind iDRAC firmware features
+Operational patterns matured with the mockey adoption for unit
+tests, reducing dependence on live hardware for development
+feedback loops.
 
 ---
 
-## Provider Pattern
+## General Context
 
-Every provider follows this structure:
+### Open Issues
 
-```go
-// provider.go
-type Provider struct {
-    client  *client.Client
-    version string
-}
+No TODO/FIXME/HACK markers found in non-test source files.
 
-func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
-    resp *provider.ConfigureResponse) {
-    // 1. Read config from HCL or environment variables
-    // 2. Initialize SDK client
-    // 3. Validate authentication (dummy API call)
-    // 4. Set resp.ResourceData and resp.DataSourceData
-}
+### Glossary
 
-func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
-    return []func() resource.Resource{
-        newVolumeResource,
-        newSnapshotRuleResource,
-        // ...
-    }
-}
-
-func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
-    return []func() datasource.DataSource{
-        newVolumeDataSource,
-        // ...
-    }
-}
-```
-
----
-
-## Resource Pattern
-
-```go
-// resource_volume.go
-type volumeResource struct {
-    client *client.Client
-}
-
-func (r *volumeResource) Create(ctx context.Context,
-    req resource.CreateRequest, resp *resource.CreateResponse) {
-    // 1. Read plan into model struct
-    // 2. Call SDK to create resource
-    // 3. Map response to state
-    // 4. Set resp.State
-}
-
-func (r *volumeResource) Read(ctx context.Context,
-    req resource.ReadRequest, resp *resource.ReadResponse) {
-    // 1. Read state into model struct
-    // 2. Call SDK to get current state
-    // 3. Map response to state (detect drift)
-    // 4. Set resp.State
-}
-
-func (r *volumeResource) Update(ctx context.Context,
-    req resource.UpdateRequest, resp *resource.UpdateResponse) {
-    // 1. Read plan and state
-    // 2. Compute diff
-    // 3. Call SDK to update
-    // 4. Set resp.State
-}
-
-func (r *volumeResource) Delete(ctx context.Context,
-    req resource.DeleteRequest, resp *resource.DeleteResponse) {
-    // 1. Read state
-    // 2. Call SDK to delete
-    // 3. State is automatically removed
-}
-
-func (r *volumeResource) ImportState(ctx context.Context,
-    req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-    // 1. Parse import ID
-    // 2. Call SDK to get resource
-    // 3. Populate state
-}
-```
-
----
-
-## Testing Patterns
-
-### Unit Tests (mockey)
-
-```go
-func TestVolumeResource_Create(t *testing.T) {
-    // Mock SDK calls using bytedance/mockey
-    mockey.PatchConvey("Create volume", t, func() {
-        mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
-        // ... test logic
-    })
-}
-```
-
-- No hardware required
-- Fast execution
-- Run with `make test`
-
-### Acceptance Tests (terraform-plugin-testing)
-
-```go
-func TestAccVolumeResource(t *testing.T) {
-    resource.Test(t, resource.TestCase{
-        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccVolumeConfig("test-vol", 10),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr("powerstore_volume.test", "name", "test-vol"),
-                    resource.TestCheckResourceAttr("powerstore_volume.test", "size", "10737418240"),
-                ),
-            },
-        },
-    })
-}
-```
-
-- **Requires live hardware**
-- Creates real resources (clean up after!)
-- Run with `TF_ACC=1 make testacc`
-
----
-
-## GoReleaser Configuration
-
-All providers use identical GoReleaser settings:
-
-```yaml
-builds:
-  - env:
-      - CGO_ENABLED=0  # Static binary, no C dependencies
-    goos:
-      - freebsd
-      - windows
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - '386'
-      - arm
-      - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'  # No 32-bit macOS
-```
-
----
-
-## Common Gotchas
-
-### 1. Endpoint URL format varies by provider
-
-- **PowerStore:** Must end with `/api/rest`
-- **PowerFlex:** Gateway URL (not MDM directly)
-- **PowerScale:** Platform API port (typically 8080)
-- **Redfish:** iDRAC IP with `/redfish/v1` path
-
-### 2. Sensitive attributes must be marked
-
-```go
-"password": schema.StringAttribute{
-    Sensitive: true,  // Required for credentials
-}
-```
-
-Without this, passwords appear in `terraform plan` output and state files.
-
-### 3. Vendored SDK updates
-
-For powerscale/powermax, SDK changes require:
-1. Edit files in `./powerscale-go-client/` or `./powermax-go-client-100/`
-2. No `go mod tidy` needed (local replace directive)
-3. Commit SDK and provider changes together
-
-### 4. Acceptance test cleanup
-
-If acceptance tests fail mid-run, resources may be left on the array.
-Clean up manually before re-running tests.
-
-### 5. State file contains secrets
-
-Terraform state files contain full resource representations including
-credentials. Always use encrypted remote backends (S3+KMS, Terraform Cloud)
-in production.
-
----
-
-## Version Compatibility
-
-| Provider | Min Terraform | Plugin Framework |
-|----------|---------------|------------------|
-| powerstore | 1.4+ | v1.13.0 |
-| powerflex | 1.4+ | v1.13.0 |
-| powerscale | 1.4+ | v1.15.1 |
-| powermax | 1.4+ | v1.19.0 |
-| objectscale | 1.4+ | v1.15.1 |
-| redfish | 1.4+ | v1.19.0 |
-| ome | 1.4+ | v1.19.0 |
-
-**Note:** powerstore still has partial `terraform-plugin-sdk/v2` dependency
-alongside the framework (migration in progress).
+| Term | Definition |
+|------|------------|
+| Plugin Framework | HashiCorp's Terraform Plugin Framework (`terraform-plugin-framework`) |
+| mockey | `bytedance/mockey` — runtime function patching for unit tests |
+| POWERFLEX | Environment variable prefix for this provider |
+| goscaleio | `github.com/dell/goscaleio` — PowerFlex REST API SDK |
+| MDM | Metadata Manager — core PowerFlex management component |
+| Gateway | PowerFlex Manager — web-based management interface |
 
 ---
 
 ## References
 
 - [Terraform Plugin Framework Docs](https://developer.hashicorp.com/terraform/plugin/framework)
-- [GoReleaser Docs](https://goreleaser.com/intro/)
-- [bytedance/mockey](https://github.com/bytedance/mockey)
 - [Dell Terraform Registry](https://registry.terraform.io/namespaces/dell)
+
+---
+
+## Governance Spec Discrepancies
+
+No discrepancies detected between code/SME knowledge and loaded
+governance specs.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,0 +1,339 @@
+# Dell Terraform Providers — Knowledge Base
+
+<!-- yaml-metadata-start -->
+scope_paths: ["./"]
+capture_git_sha: "cc98bf1c3670f31f0852fcc5c2db01139fd5f34c"
+status: "current"
+auto_update: false
+preview_before_apply: true
+scaffold_version: "1.0"
+# session_state: { is_complete: true }
+<!-- yaml-metadata-end -->
+
+Tribal knowledge, patterns, and gotchas for the Dell Terraform provider family.
+
+---
+
+## Repository Structure
+
+```
+terraform-providers/
+├── terraform-provider-powerstore/   # PowerStore arrays
+├── terraform-provider-powerflex/    # PowerFlex (VxFlex OS)
+├── terraform-provider-powerscale/   # PowerScale / Isilon
+├── terraform-provider-powermax/     # PowerMax (VMAX)
+├── terraform-provider-objectscale/  # ObjectScale (S3-compatible)
+├── terraform-provider-redfish/      # iDRAC Redfish API
+└── terraform-provider-ome/          # OpenManage Enterprise
+```
+
+Each provider is a standalone Go module with its own `go.mod`, `Makefile`,
+and release pipeline.
+
+---
+
+## Environment Variables
+
+Every provider follows the same credential injection pattern. Replace
+`<PROVIDER>` with the uppercase provider name (e.g., `POWERSTORE`, `POWERFLEX`).
+
+| Variable | Purpose |
+|----------|---------|
+| `<PROVIDER>_ENDPOINT` | Array/server management IP or FQDN |
+| `<PROVIDER>_USERNAME` | API username |
+| `<PROVIDER>_PASSWORD` | API password |
+| `<PROVIDER>_INSECURE` | `true` to skip TLS verification (lab only) |
+| `<PROVIDER>_TIMEOUT` | Request timeout in seconds (default: 120) |
+
+**Example (PowerStore):**
+```bash
+export POWERSTORE_ENDPOINT="https://10.0.0.1/api/rest"
+export POWERSTORE_USERNAME="admin"
+export POWERSTORE_PASSWORD="secret"
+export POWERSTORE_INSECURE="true"
+```
+
+Environment variables take precedence over HCL provider block values.
+
+---
+
+## Makefile Targets
+
+All providers share these standard targets:
+
+| Target | Purpose | Hardware Required |
+|--------|---------|-------------------|
+| `make build` | Compile provider binary | No |
+| `make install` | Install to `~/.terraform.d/plugins/` | No |
+| `make test` | Run unit tests | No |
+| `make testacc` | Run acceptance tests | **Yes** |
+| `make check` | Format, lint, vet | No |
+| `make gosec` | Security scan | No |
+| `make cover` | Generate coverage report | No |
+| `make generate` | Generate documentation | No |
+
+**Never run `make testacc` without live hardware credentials.** Acceptance
+tests perform real CRUD operations against arrays/servers.
+
+---
+
+## SDK Strategies
+
+### Public SDKs (gopowerstore, goscaleio)
+
+```go
+// go.mod
+require github.com/dell/gopowerstore v1.18.0
+```
+
+- Versioned Go modules on GitHub
+- Provider and SDK can release independently
+- Update SDK version in `go.mod`, run `go mod tidy`
+
+### Vendored SDKs (powerscale-go-client, powermax-go-client)
+
+```go
+// go.mod
+require dell/powerscale-go-client v0.0.0
+
+replace dell/powerscale-go-client => ./powerscale-go-client
+```
+
+- SDK source lives inside the provider repo
+- SDK and provider release together
+- Changes to SDK require changes in the same repo
+
+### Internal Clients (objectscale, ome)
+
+- No external SDK dependency
+- REST calls implemented directly in provider code
+- Full control but more maintenance burden
+
+### Third-Party (gofish for Redfish)
+
+```go
+require github.com/stmcginnis/gofish v0.20.0
+```
+
+- Vendor-neutral Redfish library (not Dell-specific)
+- Community-maintained
+- May lag behind iDRAC firmware features
+
+---
+
+## Provider Pattern
+
+Every provider follows this structure:
+
+```go
+// provider.go
+type Provider struct {
+    client  *client.Client
+    version string
+}
+
+func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
+    resp *provider.ConfigureResponse) {
+    // 1. Read config from HCL or environment variables
+    // 2. Initialize SDK client
+    // 3. Validate authentication (dummy API call)
+    // 4. Set resp.ResourceData and resp.DataSourceData
+}
+
+func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
+    return []func() resource.Resource{
+        newVolumeResource,
+        newSnapshotRuleResource,
+        // ...
+    }
+}
+
+func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
+    return []func() datasource.DataSource{
+        newVolumeDataSource,
+        // ...
+    }
+}
+```
+
+---
+
+## Resource Pattern
+
+```go
+// resource_volume.go
+type volumeResource struct {
+    client *client.Client
+}
+
+func (r *volumeResource) Create(ctx context.Context,
+    req resource.CreateRequest, resp *resource.CreateResponse) {
+    // 1. Read plan into model struct
+    // 2. Call SDK to create resource
+    // 3. Map response to state
+    // 4. Set resp.State
+}
+
+func (r *volumeResource) Read(ctx context.Context,
+    req resource.ReadRequest, resp *resource.ReadResponse) {
+    // 1. Read state into model struct
+    // 2. Call SDK to get current state
+    // 3. Map response to state (detect drift)
+    // 4. Set resp.State
+}
+
+func (r *volumeResource) Update(ctx context.Context,
+    req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // 1. Read plan and state
+    // 2. Compute diff
+    // 3. Call SDK to update
+    // 4. Set resp.State
+}
+
+func (r *volumeResource) Delete(ctx context.Context,
+    req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    // 1. Read state
+    // 2. Call SDK to delete
+    // 3. State is automatically removed
+}
+
+func (r *volumeResource) ImportState(ctx context.Context,
+    req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+    // 1. Parse import ID
+    // 2. Call SDK to get resource
+    // 3. Populate state
+}
+```
+
+---
+
+## Testing Patterns
+
+### Unit Tests (mockey)
+
+```go
+func TestVolumeResource_Create(t *testing.T) {
+    // Mock SDK calls using bytedance/mockey
+    mockey.PatchConvey("Create volume", t, func() {
+        mockey.Mock((*client.Client).CreateVolume).Return(&Volume{ID: "123"}, nil).Build()
+        // ... test logic
+    })
+}
+```
+
+- No hardware required
+- Fast execution
+- Run with `make test`
+
+### Acceptance Tests (terraform-plugin-testing)
+
+```go
+func TestAccVolumeResource(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccVolumeConfig("test-vol", 10),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("powerstore_volume.test", "name", "test-vol"),
+                    resource.TestCheckResourceAttr("powerstore_volume.test", "size", "10737418240"),
+                ),
+            },
+        },
+    })
+}
+```
+
+- **Requires live hardware**
+- Creates real resources (clean up after!)
+- Run with `TF_ACC=1 make testacc`
+
+---
+
+## GoReleaser Configuration
+
+All providers use identical GoReleaser settings:
+
+```yaml
+builds:
+  - env:
+      - CGO_ENABLED=0  # Static binary, no C dependencies
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'  # No 32-bit macOS
+```
+
+---
+
+## Common Gotchas
+
+### 1. Endpoint URL format varies by provider
+
+- **PowerStore:** Must end with `/api/rest`
+- **PowerFlex:** Gateway URL (not MDM directly)
+- **PowerScale:** Platform API port (typically 8080)
+- **Redfish:** iDRAC IP with `/redfish/v1` path
+
+### 2. Sensitive attributes must be marked
+
+```go
+"password": schema.StringAttribute{
+    Sensitive: true,  // Required for credentials
+}
+```
+
+Without this, passwords appear in `terraform plan` output and state files.
+
+### 3. Vendored SDK updates
+
+For powerscale/powermax, SDK changes require:
+1. Edit files in `./powerscale-go-client/` or `./powermax-go-client-100/`
+2. No `go mod tidy` needed (local replace directive)
+3. Commit SDK and provider changes together
+
+### 4. Acceptance test cleanup
+
+If acceptance tests fail mid-run, resources may be left on the array.
+Clean up manually before re-running tests.
+
+### 5. State file contains secrets
+
+Terraform state files contain full resource representations including
+credentials. Always use encrypted remote backends (S3+KMS, Terraform Cloud)
+in production.
+
+---
+
+## Version Compatibility
+
+| Provider | Min Terraform | Plugin Framework |
+|----------|---------------|------------------|
+| powerstore | 1.4+ | v1.13.0 |
+| powerflex | 1.4+ | v1.13.0 |
+| powerscale | 1.4+ | v1.15.1 |
+| powermax | 1.4+ | v1.19.0 |
+| objectscale | 1.4+ | v1.15.1 |
+| redfish | 1.4+ | v1.19.0 |
+| ome | 1.4+ | v1.19.0 |
+
+**Note:** powerstore still has partial `terraform-plugin-sdk/v2` dependency
+alongside the framework (migration in progress).
+
+---
+
+## References
+
+- [Terraform Plugin Framework Docs](https://developer.hashicorp.com/terraform/plugin/framework)
+- [GoReleaser Docs](https://goreleaser.com/intro/)
+- [bytedance/mockey](https://github.com/bytedance/mockey)
+- [Dell Terraform Registry](https://registry.terraform.io/namespaces/dell)


### PR DESCRIPTION
Adds KNOWLEDGE.md and ARCHITECTURE.md files with stripped-down governance metadata to the repository.

These files provide architectural context and tribal knowledge for AI-assisted development workflows.

Metadata includes only the minimal required fields:
- scope_paths
- capture_git_sha
- status
- auto_update
- preview_before_apply
- scaffold_version